### PR TITLE
tlshd: establish a priority cache at startup time

### DIFF
--- a/src/tlshd/main.c
+++ b/src/tlshd/main.c
@@ -98,8 +98,16 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
+	if (tlshd_gnutls_priority_init()) {
+		tlshd_config_shutdown();
+		tlshd_log_shutdown();
+		tlshd_log_close();
+		return EXIT_FAILURE;
+	}
+
 	tlshd_genl_dispatch();
 
+	tlshd_gnutls_priority_deinit();
 	tlshd_config_shutdown();
 	tlshd_log_shutdown();
 	tlshd_log_close();

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -74,7 +74,10 @@ extern int tlshd_keyring_link_session(const char *keyring);
 
 /* ktls.c */
 extern int tlshd_initialize_ktls(gnutls_session_t session);
-extern char *tlshd_make_priorities_string(struct tlshd_handshake_parms *parms);
+extern int tlshd_gnutls_priority_init(void);
+extern int tlshd_gnutls_priority_set(gnutls_session_t session,
+					struct tlshd_handshake_parms *parms);
+extern void tlshd_gnutls_priority_deinit(void);
 
 /* log.c */
 extern void tlshd_log_init(const char *progname);


### PR DESCRIPTION
    Review of the proposed Fedora package by Petr pointed out that tlshd
    doesn't respect system-wide preferences for cipher selection, and just
    has a hardcoded list. Also, tlshd builds a new priority string every
    time, which adds extra string-parsing overhead and such.
    
    Instead, at startup time, build priority strings (taking the local
    system preferences into account) and then use those to create two
    gnutls_priority_t objects -- one "normal" and one for pre-shared keys.
    
    Then, just attach the appropriate one to the session in
    tlshd_start_tls_handshake.
    
    Reported-by: Petr Pisar <ppisar@redhat.com>
    Signed-off-by: Jeff Layton <jlayton@kernel.org>
