### PR TITLE
Compability patches

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,9 @@ AC_CHECK_LIB([gnutls], [gnutls_transport_is_ktls_enabled],
 AC_CHECK_LIB([gnutls], [gnutls_protocol_set_enabled],
              [AC_DEFINE([HAVE_GNUTLS_PROTOCOL_SET_ENABLED], [1],
                         [Define to 1 if you have the gnutls_protocol_set_enabled function.])])
+AC_CHECK_LIB([gnutls], [gnutls_get_system_config_file],
+             [AC_DEFINE([HAVE_GNUTLS_GET_SYSTEM_CONFIG_FILE], [1],
+                        [Define to 1 if you have the gnutls_get_system_config_file function.])])
 AC_SUBST([AM_CPPFLAGS])
 
 AC_CONFIG_FILES([Makefile src/Makefile src/tlshd/Makefile systemd/Makefile])

--- a/src/tlshd/client.c
+++ b/src/tlshd/client.c
@@ -392,7 +392,10 @@ void tlshd_clienthello_handshake(struct tlshd_handshake_parms *parms)
 	gnutls_global_set_log_function(tlshd_gnutls_log_func);
 	gnutls_global_set_audit_log_function(tlshd_gnutls_audit_func);
 
-	tlshd_log_debug("System config file: %s", gnutls_get_system_config_file());
+#ifdef HAVE_GNUTLS_GET_SYSTEM_CONFIG_FILE
+	tlshd_log_debug("System config file: %s",
+			gnutls_get_system_config_file());
+#endif
 
 	switch (parms->auth_mode) {
 	case HANDSHAKE_AUTH_UNAUTH:

--- a/src/tlshd/netlink.c
+++ b/src/tlshd/netlink.c
@@ -43,6 +43,7 @@
 #include <netlink/msg.h>
 #include <netlink/genl/genl.h>
 #include <netlink/genl/ctrl.h>
+#include <netlink/version.h>
 
 #include <glib.h>
 
@@ -84,7 +85,11 @@ static void tlshd_genl_sock_close(struct nl_sock *nls)
 	nl_socket_free(nls);
 }
 
+#if LIBNL_VER_NUM >= LIBNL_VER(3,5)
 static const struct nla_policy
+#else
+static struct nla_policy
+#endif
 tlshd_accept_nl_policy[HANDSHAKE_A_ACCEPT_MAX + 1] = {
 	[HANDSHAKE_A_ACCEPT_SOCKFD]		= { .type = NLA_U32, },
 	[HANDSHAKE_A_ACCEPT_HANDLER_CLASS]	= { .type = NLA_U32, },
@@ -190,7 +195,11 @@ static void tlshd_parse_peer_identity(struct tlshd_handshake_parms *parms,
 	parms->peerids[0] = nla_get_u32(head);
 }
 
+#if LIBNL_VER_NUM >= LIBNL_VER(3,5)
 static const struct nla_policy
+#else
+static struct nla_policy
+#endif
 tlshd_x509_nl_policy[HANDSHAKE_A_X509_MAX + 1] = {
 	[HANDSHAKE_A_X509_CERT]		= { .type = NLA_U32, },
 	[HANDSHAKE_A_X509_PRIVKEY]	= { .type = NLA_U32, },

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -339,7 +339,10 @@ void tlshd_serverhello_handshake(struct tlshd_handshake_parms *parms)
 	gnutls_global_set_log_function(tlshd_gnutls_log_func);
 	gnutls_global_set_audit_log_function(tlshd_gnutls_audit_func);
 
-	tlshd_log_debug("System config file: %s", gnutls_get_system_config_file());
+#ifdef HAVE_GNUTLS_GET_SYSTEM_CONFIG_FILE
+	tlshd_log_debug("System config file: %s",
+			gnutls_get_system_config_file());
+#endif
 
 	switch (parms->auth_mode) {
 	case HANDSHAKE_AUTH_X509:


### PR DESCRIPTION
Hi all,

here are two patches which are required to have ktls-utils compile with older libraries.

Signed-off-by: Hannes Reinecke <hare@suse.de>