### PR TITLE
tlshd: add 'delay' configuration parameter

### DIFF
--- a/src/tlshd/config.c
+++ b/src/tlshd/config.c
@@ -81,6 +81,8 @@ bool tlshd_config_init(const gchar *pathname)
 						 "main", "tlsdebug", NULL);
 	nl_debug = g_key_file_get_integer(tlshd_configuration, "main",
 					  "nl_debug", NULL);
+	tlshd_delay = g_key_file_get_integer(tlshd_configuration, "main",
+					  "delay", NULL);
 
 	keyrings = g_key_file_get_string_list(tlshd_configuration, "main",
 					      "keyrings", &length, NULL);

--- a/src/tlshd/netlink.c
+++ b/src/tlshd/netlink.c
@@ -50,6 +50,8 @@
 #include "tlshd.h"
 #include "netlink.h"
 
+int tlshd_delay;
+
 static int tlshd_genl_sock_open(struct nl_sock **sock)
 {
 	struct nl_sock *nls;
@@ -467,6 +469,12 @@ void tlshd_genl_done(struct tlshd_handshake_parms *parms)
 		goto out_free;
 
 sendit:
+	if (tlshd_delay) {
+		/* delay to test timeout handling */
+		tlshd_log_debug("delay %d seconds", tlshd_delay);
+		sleep(tlshd_delay);
+	}
+
 	nl_socket_disable_auto_ack(nls);
 	err = nl_send_auto(nls, msg);
 	if (err < 0) {

--- a/src/tlshd/tlshd.conf.man
+++ b/src/tlshd/tlshd.conf.man
@@ -67,6 +67,12 @@ This option specifies an integer which indicates the debug message level
 for netlink operations.
 Zero, the quietest setting, is the default.
 .TP
+.B delay
+This options specifies an integer which indicates the number of seconds
+by which the handshake completion should be delayed. This can be used
+to exercise the timeout handling for the TLS handshake.
+Zero disables any delay.
+.TP
 .B keyrings
 This option specifies a semicolon-separated list of auxiliary keyrings
 that might contain handshake authentication tokens.

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -22,6 +22,7 @@
 
 extern int tlshd_debug;
 extern int tlshd_tls_debug;
+extern int tlshd_delay;
 extern int tlshd_stderr;
 
 struct nl_sock;


### PR DESCRIPTION
Add a 'delay' configuration parameter to delay the 'done' message for exercising the timeout handling.

Signed-off-by: Hannes Reinecke <hare@suse.de>