### PR TITLE
tlshd: fix init of privkey from keyring

### DIFF
--- a/src/tlshd/client.c
+++ b/src/tlshd/client.c
@@ -125,7 +125,7 @@ static bool tlshd_x509_client_get_privkey(struct tlshd_handshake_parms *parms)
 {
 	if (parms->x509_privkey != TLS_NO_PRIVKEY)
 		return tlshd_keyring_get_privkey(parms->x509_privkey,
-						 tlshd_privkey);
+						 &tlshd_privkey);
 	return tlshd_config_get_client_privkey(&tlshd_privkey);
 }
 

--- a/src/tlshd/keyring.c
+++ b/src/tlshd/keyring.c
@@ -121,7 +121,7 @@ bool tlshd_keyring_get_psk_key(key_serial_t serial, gnutls_datum_t *key)
  *   %true: Success; @privkey has been initialized
  *   %false: Failure
  */
-bool tlshd_keyring_get_privkey(key_serial_t serial, gnutls_privkey_t privkey)
+bool tlshd_keyring_get_privkey(key_serial_t serial, gnutls_privkey_t *privkey)
 {
 	gnutls_datum_t data;
 	void *tmp;
@@ -136,7 +136,7 @@ bool tlshd_keyring_get_privkey(key_serial_t serial, gnutls_privkey_t privkey)
 	data.data = tmp;
 	data.size = (unsigned int)ret;
 
-	ret = gnutls_privkey_init(&privkey);
+	ret = gnutls_privkey_init(privkey);
 	if (ret != GNUTLS_E_SUCCESS) {
 		tlshd_log_gnutls_error(ret);
 		free(tmp);
@@ -144,7 +144,7 @@ bool tlshd_keyring_get_privkey(key_serial_t serial, gnutls_privkey_t privkey)
 	}
 
 	/* Handshake upcall passes only DER-encoded keys */
-	ret = gnutls_privkey_import_x509_raw(privkey, &data, GNUTLS_X509_FMT_DER,
+	ret = gnutls_privkey_import_x509_raw(*privkey, &data, GNUTLS_X509_FMT_DER,
 					     NULL, 0);
 	free(tmp);
 	if (ret != GNUTLS_E_SUCCESS) {

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -61,7 +61,7 @@ static bool tlshd_x509_server_get_privkey(struct tlshd_handshake_parms *parms)
 {
 	if (parms->x509_privkey != TLS_NO_PRIVKEY)
 		return tlshd_keyring_get_privkey(parms->x509_privkey,
-						 tlshd_server_privkey);
+						 &tlshd_server_privkey);
 	return tlshd_config_get_server_privkey(&tlshd_server_privkey);
 }
 

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -71,7 +71,7 @@ extern bool tlshd_keyring_get_psk_username(key_serial_t serial,
 extern bool tlshd_keyring_get_psk_key(key_serial_t serial,
 				      gnutls_datum_t *key);
 extern bool tlshd_keyring_get_privkey(key_serial_t serial,
-				      gnutls_privkey_t privkey);
+				      gnutls_privkey_t *privkey);
 extern bool tlshd_keyring_get_cert(key_serial_t serial, gnutls_pcert_st *cert);
 extern key_serial_t tlshd_keyring_create_cert(gnutls_x509_crt_t cert,
 					      const char *peername);


### PR DESCRIPTION
When loading the private key with material from a keyring, tlshd did not initialize the static tlshd_privkey. Instead, it accidentally filled in a local copy. This lead to a failure when performing the handshake, with a general error message of:

>  tlshd[7823]: gnutls: No supported cipher suites have been found. (-87)

To fix this issue, simply supply the pointer to tlshd_privkey, like already done when loading the certificate from the config file.