### PR TITLE
tlshd: Remove tlshd_file_open()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,6 @@ PKG_CHECK_MODULES([LIBNL3], libnl-3.0 >= 3.1)
 AC_SUBST([LIBNL3_CFLAGS])
 AC_SUBST([LIBNL3_LIBS])
 
-AC_CHECK_HEADERS([linux/openat2.h])
-
 AC_CHECK_LIB([gnutls], [gnutls_transport_is_ktls_enabled],
              [AC_DEFINE([HAVE_GNUTLS_TRANSPORT_IS_KTLS_ENABLED], [1],
                         [Define to 1 if you have the gnutls_transport_is_ktls_enabled function.])])

--- a/src/tlshd/config.c
+++ b/src/tlshd/config.c
@@ -104,29 +104,6 @@ void tlshd_config_shutdown(void)
 	g_key_file_free(tlshd_configuration);
 }
 
-#if HAVE_LINUX_OPENAT2_H
-#include <linux/openat2.h>
-
-#ifndef SYS_openat2
-#define SYS_openat2 __NR_openat2
-#endif
-
-static int tlshd_file_open(const char *pathname)
-{
-	static const struct open_how how = {
-		.flags		= O_RDONLY,
-		.resolve	= RESOLVE_NO_SYMLINKS,
-	};
-
-	return (int)syscall(SYS_openat2, 0, pathname, &how, sizeof(how));
-}
-#else
-static int tlshd_file_open(const char *pathname)
-{
-	return open(pathname, O_RDONLY);
-}
-#endif
-
 /*
  * Expected file attributes
  */
@@ -148,7 +125,7 @@ static bool tlshd_config_read_datum(const char *pathname, gnutls_datum_t *data,
 
 	ret = false;
 
-	fd = tlshd_file_open(pathname);
+	fd = open(pathname, O_RDONLY);
 	if (fd == -1) {
 		tlshd_log_perror("open");
 		goto out;


### PR DESCRIPTION
WanzenBug says:
> A lot of times certificates and keys are set up in a way they can
> be rotated by changing symlinks. For example, this is common when
> using Let's Encrypt with certbot, where the canonical location for
> key material is /etc/letsencrypt/live/<host>/privkey.pem, which
> are symlinks to
> /etc/letsencrypt/archive/<host>/privkey$GENERATION.pem. Every time
> the certificate gets renewed, the symlinks are updated.

Our security reviewers agree that there is no need for the extra restriction, as most modern Linux distributions have fs.protected_symlinks to prevent TOCTOU symlink vulnerabilities.

Addresses Issue #37.