### PR TITLE
tlshd: Add support for chained certs

### DIFF
--- a/src/tlshd/config.c
+++ b/src/tlshd/config.c
@@ -196,14 +196,16 @@ bool tlshd_config_get_client_truststore(char **bundle)
 }
 
 /**
- * tlshd_config_get_client_cert - Get cert for ClientHello from .conf
- * @cert: OUT: in-memory certificate
+ * tlshd_config_get_client_certs - Get certs for ClientHello from .conf
+ * @certs: OUT: in-memory certificates
+ * @certs_len: IN: maximum number of certs to get, OUT: number of certs found
  *
  * Return values:
  *   %true: certificate retrieved successfully
  *   %false: certificate not retrieved
  */
-bool tlshd_config_get_client_cert(gnutls_pcert_st *cert)
+bool tlshd_config_get_client_certs(gnutls_pcert_st *certs,
+				   unsigned int *certs_len)
 {
 	GError *error = NULL;
 	gnutls_datum_t data;
@@ -224,8 +226,8 @@ bool tlshd_config_get_client_cert(gnutls_pcert_st *cert)
 	}
 
 	/* Config file supports only PEM-encoded certificates */
-	ret = gnutls_pcert_import_x509_raw(cert, &data,
-					   GNUTLS_X509_FMT_PEM, 0);
+	ret = gnutls_pcert_list_import_x509_raw(certs, certs_len, &data,
+						GNUTLS_X509_FMT_PEM, 0);
 	free(data.data);
 	if (ret != GNUTLS_E_SUCCESS) {
 		tlshd_log_gnutls_error(ret);
@@ -233,7 +235,8 @@ bool tlshd_config_get_client_cert(gnutls_pcert_st *cert)
 		return false;
 	}
 
-	tlshd_log_debug("Retrieved x.509 certificate from %s", pathname);
+	tlshd_log_debug("Retrieved %u x.509 client certificate(s) from %s",
+			*certs_len, pathname);
 	g_free(pathname);
 	return true;
 }
@@ -319,14 +322,16 @@ bool tlshd_config_get_server_truststore(char **bundle)
 }
 
 /**
- * tlshd_config_get_server_cert - Get cert for ServerHello from .conf
- * @cert: OUT: in-memory certificate
+ * tlshd_config_get_server_certs - Get certs for ServerHello from .conf
+ * @certs: OUT: in-memory certificates
+ * @certs_len: IN: maximum number of certs to get, OUT: number of certs found
  *
  * Return values:
  *   %true: certificate retrieved successfully
  *   %false: certificate not retrieved
  */
-bool tlshd_config_get_server_cert(gnutls_pcert_st *cert)
+bool tlshd_config_get_server_certs(gnutls_pcert_st *certs,
+				   unsigned int *certs_len)
 {
 	GError *error = NULL;
 	gnutls_datum_t data;
@@ -347,8 +352,8 @@ bool tlshd_config_get_server_cert(gnutls_pcert_st *cert)
 	}
 
 	/* Config file supports only PEM-encoded certificates */
-	ret = gnutls_pcert_import_x509_raw(cert, &data,
-					   GNUTLS_X509_FMT_PEM, 0);
+	ret = gnutls_pcert_list_import_x509_raw(certs, certs_len, &data,
+						GNUTLS_X509_FMT_PEM, 0);
 	free(data.data);
 	if (ret != GNUTLS_E_SUCCESS) {
 		tlshd_log_gnutls_error(ret);
@@ -356,7 +361,8 @@ bool tlshd_config_get_server_cert(gnutls_pcert_st *cert)
 		return false;
 	}
 
-	tlshd_log_debug("Retrieved x.509 certificate from %s", pathname);
+	tlshd_log_debug("Retrieved %u x.509 server certificate(s) from %s",
+			*certs_len, pathname);
 	return true;
 }
 

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -54,10 +54,12 @@ extern void tlshd_clienthello_handshake(struct tlshd_handshake_parms *parms);
 bool tlshd_config_init(const gchar *pathname);
 void tlshd_config_shutdown(void);
 bool tlshd_config_get_client_truststore(char **bundle);
-bool tlshd_config_get_client_cert(gnutls_pcert_st *cert);
+bool tlshd_config_get_client_certs(gnutls_pcert_st *certs,
+				   unsigned int *certs_len);
 bool tlshd_config_get_client_privkey(gnutls_privkey_t *privkey);
 bool tlshd_config_get_server_truststore(char **bundle);
-bool tlshd_config_get_server_cert(gnutls_pcert_st *cert);
+bool tlshd_config_get_server_certs(gnutls_pcert_st *certs,
+				   unsigned int *certs_len);
 bool tlshd_config_get_server_privkey(gnutls_privkey_t *privkey);
 
 /* handshake.c */
@@ -72,7 +74,8 @@ extern bool tlshd_keyring_get_psk_key(key_serial_t serial,
 				      gnutls_datum_t *key);
 extern bool tlshd_keyring_get_privkey(key_serial_t serial,
 				      gnutls_privkey_t *privkey);
-extern bool tlshd_keyring_get_cert(key_serial_t serial, gnutls_pcert_st *cert);
+extern bool tlshd_keyring_get_certs(key_serial_t serial, gnutls_pcert_st *certs,
+				    unsigned int *certs_len);
 extern key_serial_t tlshd_keyring_create_cert(gnutls_x509_crt_t cert,
 					      const char *peername);
 extern int tlshd_keyring_link_session(const char *keyring);
@@ -120,3 +123,5 @@ extern void tlshd_serverhello_handshake(struct tlshd_handshake_parms *parms);
 #define TLS_NO_PEERID		(0)
 #define TLS_NO_CERT		(0)
 #define TLS_NO_PRIVKEY		(0)
+/* Max number of (chained) certs to load */
+#define TLSHD_MAX_CERTS		10


### PR DESCRIPTION
This patch adds support for chained certs (e.g. client/server .pem file which includes an intermediate CA cert as well as the actual client/server cert).

Tested with a client/server NFS setup (using xprtsec=mtls) where only the root CA is in the system trust store and both the client and server use chained certificates with an intermediate CA as part of the cert.

Fixes: #44