### PR TITLE
Restrict announced hash value for PSK

### DIFF
--- a/src/tlshd/client.c
+++ b/src/tlshd/client.c
@@ -382,6 +382,12 @@ static void tlshd_client_psk_handshake_one(struct tlshd_handshake_parms *parms,
 		goto out_free_creds;
 	}
 
+	ret = tlshd_gnutls_priority_restrict(session, key.size);
+	if (ret != GNUTLS_E_SUCCESS) {
+		tlshd_log_gnutls_error(ret);
+		goto out_free_creds;
+	}
+
 	tlshd_log_debug("start ClientHello handshake");
 	tlshd_start_tls_handshake(session, parms);
 	if (!parms->session_status) {

--- a/src/tlshd/handshake.c
+++ b/src/tlshd/handshake.c
@@ -83,12 +83,6 @@ void tlshd_start_tls_handshake(gnutls_session_t session,
 	int saved, ret;
 	char *desc;
 
-	ret = tlshd_gnutls_priority_set(session, parms);
-	if (ret != GNUTLS_E_SUCCESS) {
-		tlshd_log_gnutls_error(ret);
-		return;
-	}
-
 	gnutls_handshake_set_timeout(session, parms->timeout_ms);
 	tlshd_save_nagle(session, &saved);
 	do {

--- a/src/tlshd/ktls.c
+++ b/src/tlshd/ktls.c
@@ -429,6 +429,39 @@ int tlshd_gnutls_priority_init(void)
 }
 
 /**
+ * tlshd_gnutls_priority_restrict - Disable specific hash functions
+ * @session: session to initialize
+ * @key_size: length of the selected PSK
+ *
+ * Restrict the set of hash functions to those matching the current
+ * PSK key length.
+ *
+ * Note: this is function actually does the reverse by disabling
+ * the non-matchine SHA functions.
+ *
+ * Returns GNUTLS_E_SUCCESS on success, otherwise an error code.
+ */
+int tlshd_gnutls_priority_restrict(gnutls_session_t session,
+				   unsigned int key_size)
+{
+	const char *err;
+	int ret;
+
+	if (key_size == 32)
+		ret = gnutls_set_default_priority_append(session,
+							 "-SHA384",
+							 &err, 0);
+	else if (key_size == 48)
+		ret = gnutls_set_default_priority_append(session,
+							 "-SHA256",
+							 &err, 0);
+	else
+		ret = GNUTLS_E_UNIMPLEMENTED_FEATURE;
+
+	return ret;
+}
+
+/**
  * tlshd_gnutls_priority_set - Initialize priorities per-session
  * @session: session to initialize
  * @parms: handshake parameters

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -85,6 +85,8 @@ extern unsigned int tlshd_initialize_ktls(gnutls_session_t session);
 extern int tlshd_gnutls_priority_init(void);
 extern int tlshd_gnutls_priority_set(gnutls_session_t session,
 					struct tlshd_handshake_parms *parms);
+extern int tlshd_gnutls_priority_restrict(gnutls_session_t session,
+					  unsigned int key_len);
 extern void tlshd_gnutls_priority_deinit(void);
 
 /* log.c */


### PR DESCRIPTION
PSK ClientHello only sends a single PSK value, which matches only to one hash algorithm. So we should restrict the announced hash values to only the correct one.