### PR TITLE
Fixup priority setting

### DIFF
--- a/src/tlshd/client.c
+++ b/src/tlshd/client.c
@@ -95,7 +95,7 @@ static void tlshd_client_anon_handshake(struct tlshd_handshake_parms *parms)
 		goto out_free_creds;
 	}
 
-	ret = tlshd_gnutls_priority_set(session, parms);
+	ret = tlshd_gnutls_priority_set(session, parms, 0);
 	if (ret != GNUTLS_E_SUCCESS) {
 		tlshd_log_gnutls_error(ret);
 		goto out_free_creds;
@@ -315,7 +315,7 @@ static void tlshd_client_x509_handshake(struct tlshd_handshake_parms *parms)
 		tlshd_log_gnutls_error(ret);
 		goto out_free_creds;
 	}
-	ret = tlshd_gnutls_priority_set(session, parms);
+	ret = tlshd_gnutls_priority_set(session, parms, 0);
 	if (ret != GNUTLS_E_SUCCESS) {
 		tlshd_log_gnutls_error(ret);
 		goto out_free_creds;
@@ -376,13 +376,7 @@ static void tlshd_client_psk_handshake_one(struct tlshd_handshake_parms *parms,
 	gnutls_session_set_ptr(session, parms);
 	gnutls_credentials_set(session, GNUTLS_CRD_PSK, psk_cred);
 
-	ret = tlshd_gnutls_priority_set(session, parms);
-	if (ret != GNUTLS_E_SUCCESS) {
-		tlshd_log_gnutls_error(ret);
-		goto out_free_creds;
-	}
-
-	ret = tlshd_gnutls_priority_restrict(session, key.size);
+	ret = tlshd_gnutls_priority_set(session, parms, key.size);
 	if (ret != GNUTLS_E_SUCCESS) {
 		tlshd_log_gnutls_error(ret);
 		goto out_free_creds;

--- a/src/tlshd/config.c
+++ b/src/tlshd/config.c
@@ -87,7 +87,7 @@ bool tlshd_config_init(const gchar *pathname)
 	tlshd_delay_done = tmp > 0 ? tmp : 0;
 
 	keyrings = g_key_file_get_string_list(tlshd_configuration,
-					      "authentication",
+					      "authenticate",
 					      "keyrings", &length, NULL);
 	if (keyrings) {
 		for (i = 0; i < length; i++) {

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -258,7 +258,7 @@ static void tlshd_server_x509_handshake(struct tlshd_handshake_parms *parms)
 					       tlshd_server_x509_verify_function);
 	gnutls_certificate_server_set_request(session, GNUTLS_CERT_REQUEST);
 
-	ret = tlshd_gnutls_priority_set(session, parms);
+	ret = tlshd_gnutls_priority_set(session, parms, 0);
 	if (ret) {
 		tlshd_log_gnutls_error(ret);
 		goto out_free_creds;
@@ -337,7 +337,7 @@ static void tlshd_server_psk_handshake(struct tlshd_handshake_parms *parms)
 
 	gnutls_credentials_set(session, GNUTLS_CRD_PSK, psk_cred);
 
-	ret = tlshd_gnutls_priority_set(session, parms);
+	ret = tlshd_gnutls_priority_set(session, parms, 0);
 	if (ret) {
 		tlshd_log_gnutls_error(ret);
 		goto out_free_creds;

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -258,6 +258,12 @@ static void tlshd_server_x509_handshake(struct tlshd_handshake_parms *parms)
 					       tlshd_server_x509_verify_function);
 	gnutls_certificate_server_set_request(session, GNUTLS_CERT_REQUEST);
 
+	ret = tlshd_gnutls_priority_set(session, parms);
+	if (ret) {
+		tlshd_log_gnutls_error(ret);
+		goto out_free_creds;
+	}
+
 	tlshd_start_tls_handshake(session, parms);
 
 	gnutls_deinit(session);
@@ -330,6 +336,12 @@ static void tlshd_server_psk_handshake(struct tlshd_handshake_parms *parms)
 	gnutls_session_set_ptr(session, parms);
 
 	gnutls_credentials_set(session, GNUTLS_CRD_PSK, psk_cred);
+
+	ret = tlshd_gnutls_priority_set(session, parms);
+	if (ret) {
+		tlshd_log_gnutls_error(ret);
+		goto out_free_creds;
+	}
 
 	tlshd_start_tls_handshake(session, parms);
 

--- a/src/tlshd/tlshd.conf.man
+++ b/src/tlshd/tlshd.conf.man
@@ -68,7 +68,7 @@ for netlink library calls.
 Zero, the quietest setting, is the default.
 .P
 The
-.I [authentication]
+.I [authenticate]
 section specifies default authentication material when establishing
 TLS sessions.
 In this section, there is one available option:

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -84,9 +84,8 @@ extern int tlshd_keyring_link_session(const char *keyring);
 extern unsigned int tlshd_initialize_ktls(gnutls_session_t session);
 extern int tlshd_gnutls_priority_init(void);
 extern int tlshd_gnutls_priority_set(gnutls_session_t session,
-					struct tlshd_handshake_parms *parms);
-extern int tlshd_gnutls_priority_restrict(gnutls_session_t session,
-					  unsigned int key_len);
+				     struct tlshd_handshake_parms *parms,
+				     int psk_len);
 extern void tlshd_gnutls_priority_deinit(void);
 
 /* log.c */


### PR DESCRIPTION
PSK mode has its own rules which cipher suites should be selected; as we're only ever sending a single PSK for each ClientHello we really should only include matching cipher suites to avoid the server selecting a mismatching cipher suite.