### PR TITLE
README: Indicate additional kernel dependency for ktls-utils

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,8 @@ this package is released.
 
 ## Dependencies
 
-* The local kernel must be built with CONFIG_TLS enabled
+* The local kernel must have net/handshake support and be built with
+  CONFIG_TLS enabled
 * The local build environment requires GnuTLS and keyutils
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ this package is released.
 
 ## Dependencies
 
-* The local kernel must be built with CONFIG_TLS enabled
+* The local kernel must have net/handshake support and be built with
+  CONFIG_TLS enabled
 * The local build environment requires GnuTLS and keyutils
 
 ## Installation


### PR DESCRIPTION
It was noted in Issue #52 that the README needs to mention the minimum kernel support required for ktls-utils to work.

It turns out not to be a straightforward thing to add. Support for in-kernel TLS handshakes were added to the SunRPC server in v6.5; to the SunRPC client in v6.6; and for NVMe in later releases. Moreover, some of this has been backported into older distribution kernels. Keeping track of distribution kernels is not possible here.