### PR TITLE
add option to skip server certificate check

### DIFF
--- a/src/tlshd/config.c
+++ b/src/tlshd/config.c
@@ -96,6 +96,19 @@ bool tlshd_config_init(const gchar *pathname)
 		g_strfreev(keyrings);
 	}
 
+	/*
+	 * If 'no_certificate_check' exists in the client configuration
+     * section AND it is non-zero, then don't check the certificate
+     * presented to the client by the server.
+	 */
+	if (g_key_file_get_integer(tlshd_configuration,
+				   "authenticate.client",
+				   "no_certificate_check", NULL)) {
+		server_cert_check = 0;
+	} else {
+		server_cert_check = 1;
+	}
+
 	return true;
 }
 

--- a/src/tlshd/tlshd.conf
+++ b/src/tlshd/tlshd.conf
@@ -32,6 +32,7 @@ nl=0
 #x509.truststore= <pathname>
 #x509.certificate= <pathname>
 #x509.private_key= <pathname>
+#no_certificate_check= 1 # Disable checking server certificate
 
 [authenticate.server]
 #x509.truststore= <pathname>

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -24,6 +24,7 @@ extern int tlshd_debug;
 extern int tlshd_tls_debug;
 extern unsigned int tlshd_delay_done;
 extern int tlshd_stderr;
+extern int server_cert_check;
 
 struct nl_sock;
 


### PR DESCRIPTION
This is useful for debugging.  I have an NFS server in which non production builds will generate an x509 on the fly and send that to the client.  The client has no way to have proper truststore to verify that certificate, so the client must ignore it.  To enable no certificate checking, use the following config...

   [authenticate.client]
   no_certificate_check = 1

Testing done to verify...
 * Tested with x509.truststore=...
 * Tested with no_certificate_check=0
 * Tested with no_certificate_check=1