### PR TITLE
add handshake support for in-kernel QUIC

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -30,6 +30,7 @@ done
 
 rm -f ktls-utils*.tar.gz
 
+libtoolize --force --copy
 aclocal
 autoheader
 automake --add-missing --copy --gnu

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,16 @@ AC_ARG_WITH(systemd,
 	AM_CONDITIONAL(INSTALL_SYSTEMD, [test "$use_systemd" = 1])
 	AC_SUBST(unitdir)
 
+AC_ARG_ENABLE(quic, [AS_HELP_STRING([--enable-quic], [enable quic @<:@Default: no@:>@])], [enable_quic=1])
+	AS_IF([test "$enable_quic" = 1],
+	      [AC_CHECK_FILE([/usr/include/linux/quic.h], [], [AC_MSG_ERROR([no quic module found])])
+	       AC_SUBST([LIBQUIC], [libquic])
+	       AC_SUBST([LIBQUIC_CFLAGS], ['-I$(top_srcdir)/src/libquic/'])
+	       AC_SUBST([LIBQUIC_LIBS], ['$(top_srcdir)/src/libquic/libquic.la'])
+	       AC_CONFIG_FILES([src/libquic/Makefile src/libquic/libquic.pc])
+	       AC_DEFINE([HAVE_QUIC], [1], [Define to 1 if QUIC is enabled.])])
+	LT_INIT
+
 PKG_PROG_PKG_CONFIG([0.9.0])
 PKG_CHECK_MODULES([LIBGNUTLS], [gnutls >= 3.3.0])
 AC_SUBST([LIBGNUTLS_CFLAGS])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,5 +16,5 @@
 # 02110-1301, USA.
 #
 
-SUBDIRS			= tlshd
+SUBDIRS			= $(LIBQUIC) tlshd
 MAINTAINERCLEANFILES	= Makefile.in

--- a/src/libquic/Makefile.am
+++ b/src/libquic/Makefile.am
@@ -1,0 +1,16 @@
+man7_MANS		= quic.man
+EXTRA_DIST		= $(man7_MANS)
+
+lib_LTLIBRARIES		= libquic.la
+libquic_la_SOURCES	= connection.c crypto.c libquic.h
+libquic_la_CFLAGS	= -Werror -Wall $(LIBGNUTLS_CFLAGS)
+libquic_la_LIBADD	= $(LIBGNUTLS_LIBS)
+libquic_la_LDFLAGS	= -version-info 1:0:0
+
+libcnetinetdir		= $(includedir)/netinet
+libcnetinet_HEADERS	= quic.h
+
+pkgconfigdir		= $(libdir)/pkgconfig
+pkgconfig_DATA		= libquic.pc
+
+MAINTAINERCLEANFILES	= Makefile.in

--- a/src/libquic/connection.c
+++ b/src/libquic/connection.c
@@ -1,0 +1,706 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* QUIC kernel implementation
+ * (C) Copyright Red Hat Corp. 2023
+ *
+ * This file is the userspace handshake part for the QUIC kernel implementation
+ *
+ * Initialization/cleanup for QUIC protocol support.
+ *
+ * Written or modified by:
+ *    Xin Long <lucien.xin@gmail.com>
+ */
+
+#include "libquic.h"
+
+static int read_psk_file(char *psk, char *identity[], gnutls_datum_t *pkey)
+{
+	unsigned char *end, *key, *buf;
+	int fd, err = -1, i = 0;
+	struct stat statbuf;
+	gnutls_datum_t gkey;
+	unsigned int size;
+
+	fd = open(psk, O_RDONLY);
+	if (fd == -1)
+		return -1;
+	if (fstat(fd, &statbuf))
+		goto out;
+
+	size = (unsigned int)statbuf.st_size;
+	buf = malloc(size);
+	if (!buf)
+		goto out;
+	if (read(fd, buf, size) == -1) {
+		free(buf);
+		goto out;
+	}
+
+	end = buf + size - 1;
+	do {
+		key = (unsigned char *)strchr((char *)buf, ':');
+		if (!key)
+			goto out;
+		*key = '\0';
+		identity[i] = (char *)buf;
+
+		key++;
+		gkey.data = key;
+
+		buf = (unsigned char *)strchr((char *)key, '\n');
+		if (!buf) {
+			gkey.size = end - gkey.data;
+			buf = end;
+			goto decode;
+		}
+		*buf = '\0';
+		buf++;
+		gkey.size = strlen((char *)gkey.data);
+decode:
+		if (gnutls_hex_decode2(&gkey, &pkey[i]))
+			goto out;
+		i++;
+	} while (buf < end);
+
+	err = i;
+out:
+	close(fd);
+	return err;
+}
+
+static int read_datum(const char *file, gnutls_datum_t *data)
+{
+	struct stat statbuf;
+	unsigned int size;
+	int ret = -1;
+	void *buf;
+	int fd;
+
+	fd = open(file, O_RDONLY);
+	if (fd == -1)
+		return -1;
+	if (fstat(fd, &statbuf))
+		goto out;
+	if (statbuf.st_size < 0 || statbuf.st_size > INT_MAX)
+		goto out;
+	size = (unsigned int)statbuf.st_size;
+	buf = malloc(size);
+	if (!buf)
+		goto out;
+	if (read(fd, buf, size) == -1) {
+		free(buf);
+		goto out;
+	}
+	data->data = buf;
+	data->size = size;
+	ret = 0;
+out:
+	close(fd);
+	return ret;
+}
+
+static int read_pkey_file(char *file, gnutls_privkey_t *privkey)
+{
+	gnutls_datum_t data;
+	int ret;
+
+	if (read_datum(file, &data))
+		return -1;
+
+	ret = gnutls_privkey_init(privkey);
+	if (ret)
+		goto out;
+
+	ret = gnutls_privkey_import_x509_raw(*privkey, &data, GNUTLS_X509_FMT_PEM, NULL, 0);
+out:
+	free(data.data);
+	return ret;
+}
+
+static int read_cert_file(char *file, gnutls_pcert_st **cert)
+{
+	gnutls_datum_t data;
+	int ret;
+
+	if (read_datum(file, &data))
+		return -1;
+
+	ret = gnutls_pcert_import_x509_raw(*cert, &data, GNUTLS_X509_FMT_PEM, 0);
+	free(data.data);
+
+	return ret;
+}
+
+static void timer_handler(union sigval arg)
+{
+	struct quic_conn *conn = arg.sival_ptr;
+
+	conn->errcode = ETIMEDOUT;
+}
+
+static int set_nonblocking(int sockfd, uint8_t nonblocking)
+{
+	int flags = fcntl(sockfd, F_GETFL, 0);
+
+	if (flags == -1) {
+		pr_error("fcntl");
+		return -1;
+	}
+
+	if (nonblocking)
+		flags |= O_NONBLOCK;
+	else
+		flags &= ~O_NONBLOCK;
+
+	if (fcntl(sockfd, F_SETFL, flags) == -1) {
+		pr_error("fcntl");
+		return -1;
+	}
+	return 0;
+}
+
+static int setup_timer(struct quic_conn *conn)
+{
+	uint64_t msec = conn->parms->timeout;
+	struct itimerspec its = {};
+	struct sigevent sev = {};
+
+	if (set_nonblocking(conn->sockfd, 1))
+		return -1;
+
+	sev.sigev_notify = SIGEV_THREAD;
+	sev.sigev_notify_function = timer_handler;
+	sev.sigev_value.sival_ptr = conn;
+	timer_create(CLOCK_REALTIME, &sev, &conn->timer);
+
+	its.it_value.tv_sec  = msec / 1000;
+	its.it_value.tv_nsec = (msec % 1000) * 1000000;
+	timer_settime(conn->timer, 0, &its, NULL);
+	return 0;
+}
+
+static int delete_timer(struct quic_conn *conn)
+{
+	set_nonblocking(conn->sockfd, 0);
+	timer_delete(conn->timer);
+	return 0;
+}
+
+static int get_transport_param(struct quic_conn *conn)
+{
+	struct quic_transport_param param = {};
+	int sockfd = conn->sockfd;
+	unsigned int len;
+
+	len = sizeof(conn->alpn.data);
+	if (getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_ALPN, conn->alpn.data, &len)) {
+		pr_error("socket getsockopt alpn failed\n");
+		return -1;
+	}
+	conn->alpn.datalen = len;
+	len = sizeof(conn->ticket.buf);
+	if (getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_SESSION_TICKET, conn->ticket.buf, &len)) {
+		pr_error("socket getsockopt session ticket failed\n");
+		return -1;
+	}
+	conn->ticket.buflen = len;
+	len = sizeof(param);
+	if (getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_TRANSPORT_PARAM, &param, &len)) {
+		pr_error("socket getsockopt transport param failed\n");
+		return -1;
+	}
+	conn->recv_ticket = param.receive_session_ticket;
+	conn->cert_req = param.certificate_request;
+	conn->cipher = param.payload_cipher_type;
+	conn->sockfd = sockfd;
+	return 0;
+}
+
+static int conn_destroy(struct quic_conn *conn)
+{
+	struct quic_frame *frame = conn->send_list;
+	int ret;
+
+	while (frame) {
+		conn->send_list = frame->next;
+		free(frame);
+		frame = conn->send_list;
+	}
+	delete_timer(conn);
+	gnutls_deinit(conn->session);
+	ret = conn->errcode;
+	free(conn);
+	return -ret;
+}
+
+static struct quic_conn *conn_create(int sockfd, struct quic_handshake_parms *parms, uint8_t server)
+{
+	struct quic_conn *conn;
+
+	conn = malloc(sizeof(*conn));
+	if (!conn)
+		return NULL;
+
+	memset(conn, 0, sizeof(*conn));
+	conn->parms = parms;
+	conn->sockfd = sockfd;
+
+	if (get_transport_param(conn))
+		goto err;
+
+	if (setup_timer(conn))
+		goto err;
+
+	return conn;
+err:
+	conn_destroy(conn);
+	return NULL;
+}
+
+static int conn_sendmsg(int sockfd, struct quic_frame *frame)
+{
+	char outcmsg[CMSG_SPACE(sizeof(struct quic_handshake_info))];
+	struct quic_handshake_info *info;
+	struct msghdr outmsg;
+	struct cmsghdr *cmsg;
+	struct iovec iov;
+	int flags = 0;
+
+	outmsg.msg_name = NULL;
+	outmsg.msg_namelen = 0;
+	outmsg.msg_iov = &iov;
+	iov.iov_base = (void *)frame->data.buf;
+	iov.iov_len = frame->data.buflen;
+	outmsg.msg_iovlen = 1;
+
+	outmsg.msg_control = outcmsg;
+	outmsg.msg_controllen = sizeof(outcmsg);
+	outmsg.msg_flags = 0;
+	if (frame->next)
+		flags = MSG_MORE;
+
+	cmsg = CMSG_FIRSTHDR(&outmsg);
+	cmsg->cmsg_level = IPPROTO_QUIC;
+	cmsg->cmsg_type = QUIC_HANDSHAKE_INFO;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(*info));
+
+	info = (struct quic_handshake_info *)CMSG_DATA(cmsg);
+	info->crypto_level = frame->level;
+
+	return sendmsg(sockfd, &outmsg, flags);
+}
+
+static int conn_recvmsg(int sockfd, struct quic_frame *frame)
+{
+	char incmsg[CMSG_SPACE(sizeof(struct quic_handshake_info))];
+	struct quic_handshake_info info;
+	struct cmsghdr *cmsg = NULL;
+	struct msghdr inmsg;
+	struct iovec iov;
+	int error;
+
+	frame->data.buflen = 0;
+	memset(&inmsg, 0, sizeof(inmsg));
+
+	iov.iov_base = frame->data.buf;
+	iov.iov_len = sizeof(frame->data.buf);
+
+	inmsg.msg_name = NULL;
+	inmsg.msg_namelen = 0;
+	inmsg.msg_iov = &iov;
+	inmsg.msg_iovlen = 1;
+	inmsg.msg_control = incmsg;
+	inmsg.msg_controllen = sizeof(incmsg);
+
+	error = recvmsg(sockfd, &inmsg, 0);
+	if (error < 0)
+		return error;
+	frame->data.buflen = error;
+
+	for (cmsg = CMSG_FIRSTHDR(&inmsg); cmsg != NULL; cmsg = CMSG_NXTHDR(&inmsg, cmsg))
+		if (IPPROTO_QUIC == cmsg->cmsg_level && QUIC_HANDSHAKE_INFO == cmsg->cmsg_type)
+			break;
+	if (cmsg) {
+		memcpy(&info, CMSG_DATA(cmsg), sizeof(info));
+		frame->level = info.crypto_level;
+	}
+
+	return error;
+}
+
+static int conn_handshake_completed(struct quic_conn *conn)
+{
+	return conn->completed || conn->errcode;
+}
+
+static void conn_do_handshake(struct quic_conn *conn)
+{
+	int ret, sockfd = conn->sockfd;
+	struct timeval tv = {1, 0};
+	struct quic_frame *frame;
+	fd_set readfds;
+
+	FD_ZERO(&readfds);
+	FD_SET(sockfd, &readfds);
+
+	while (!conn_handshake_completed(conn)) {
+		ret = select(sockfd + 1, &readfds, NULL,  NULL, &tv);
+		if (ret < 0) {
+			conn->errcode = errno;
+			return;
+		}
+		frame = &conn->frame;
+		while (!conn_handshake_completed(conn)) {
+			ret = conn_recvmsg(sockfd, frame);
+			if (ret <= 0) {
+				if (errno == EAGAIN || errno == EWOULDBLOCK)
+					break;
+				conn->errcode = errno;
+				return;
+			}
+			pr_debug("v %s RECV: %d %d\n", __func__, frame->data.buflen, frame->level);
+			ret = quic_crypto_read_write_crypto_data(conn, frame->level,
+								 frame->data.buf,
+								 frame->data.buflen);
+			if (ret) {
+				conn->errcode = -ret;
+				return;
+			}
+		}
+
+		frame = conn->send_list;
+		while (frame) {
+			pr_debug("^ %s SEND: %d %d\n", __func__, frame->data.buflen, frame->level);
+			ret = conn_sendmsg(sockfd, frame);
+			if (ret < 0) {
+				conn->errcode = errno;
+				return;
+			}
+			conn->send_list = frame->next;
+			free(frame);
+			frame = conn->send_list;
+		}
+	}
+}
+
+static int quic_log_level = 2;
+
+static void _pr_debug(char const *fmt, ...)
+{
+	va_list arg;
+
+	if (quic_log_level < 3)
+		return;
+	printf("[DEBUG] ");
+	va_start(arg, fmt);
+	vprintf(fmt, arg);
+	va_end(arg);
+}
+
+static void _pr_warn(char const *fmt, ...)
+{
+	va_list arg;
+
+	if (quic_log_level < 2)
+		return;
+	printf("[WARN] ");
+	va_start(arg, fmt);
+	vprintf(fmt, arg);
+	va_end(arg);
+}
+
+static void _pr_error(char const *fmt, ...)
+{
+	va_list arg;
+
+	if (quic_log_level < 1)
+		return;
+	printf("[ERROR] ");
+	va_start(arg, fmt);
+	vprintf(fmt, arg);
+	va_end(arg);
+}
+
+quic_log_func pr_error = _pr_error;
+quic_log_func pr_warn  = _pr_warn;
+quic_log_func pr_debug = _pr_debug;
+
+/**
+ * quic_set_log_level - change the log_level
+ * @level: the level it changes to, the value can be:
+ *
+ * 1: LOGLEVEL_ERROR
+ * 2: LOGLEVEL_WARN (default)
+ * 3: LOGLEVEL_DEBUG
+ */
+void quic_set_log_level(int level)
+{
+	quic_log_level = level;
+}
+
+/**
+ * quic_set_log_funcs - change the log_func for each level
+ * @debug: the log func for debug log level
+ * @warn:  the log func for warn  log level
+ * @error: the log func for error log level
+ */
+void quic_set_log_funcs(quic_log_func debug, quic_log_func warn, quic_log_func error)
+{
+	if (debug)
+		pr_debug = debug;
+	if (warn)
+		pr_warn  = warn;
+	if (error)
+		pr_error = error;
+}
+
+/**
+ * quic_client_handshake_parms - start a QUIC handshake with Certificate or PSK mode on client side
+ * @sockfd: IPPROTO_QUIC type socket
+ * @parms: parameters for handshake, see struct quic_handshake_parms
+ *
+ * Return values:
+ * - On success, 0.
+ * - On error, the error is returned.
+ */
+int quic_client_handshake_parms(int sockfd, struct quic_handshake_parms *parms)
+{
+	struct quic_frame *frame;
+	struct quic_conn *conn;
+	int ret, level;
+
+	conn = conn_create(sockfd, parms, 0);
+	if (!conn)
+		return -ENOMEM;
+
+	ret = parms->num_keys ? quic_crypto_client_set_psk_session(conn)
+			      : quic_crypto_client_set_x509_session(conn);
+	if (ret) {
+		conn->errcode = -ret;
+		goto out;
+	}
+
+	level = QUIC_CRYPTO_INITIAL;
+	ret = quic_crypto_read_write_crypto_data(conn, level, NULL, 0);
+	if (ret) {
+		conn->errcode = -ret;
+		goto out;
+	}
+
+	frame = conn->send_list;
+	while (frame) {
+		pr_debug("^ %s SEND: %d %d\n", __func__, frame->data.buflen, frame->level);
+		ret = conn_sendmsg(sockfd, frame);
+		if (ret < 0) {
+			conn->errcode = errno;
+			goto out;
+		}
+		conn->send_list = frame->next;
+		free(frame);
+		frame = conn->send_list;
+	}
+
+	conn_do_handshake(conn);
+out:
+	return conn_destroy(conn);
+}
+
+/**
+ * quic_server_handshake_parms - start a QUIC handshake with Certificate or PSK mode on server side
+ * @sockfd: IPPROTO_QUIC type socket
+ * @parms: parameters for handshake, see struct quic_handshake_parms
+ *
+ * Return values:
+ * - On success, 0.
+ * - On error, the error is returned.
+ */
+int quic_server_handshake_parms(int sockfd, struct quic_handshake_parms *parms)
+{
+	struct quic_conn *conn;
+	int ret;
+
+	conn = conn_create(sockfd, parms, 1);
+	if (!conn)
+		return -ENOMEM;
+
+	ret = parms->num_keys ? quic_crypto_server_set_psk_session(conn)
+			      : quic_crypto_server_set_x509_session(conn);
+	if (ret) {
+		conn->errcode = -ret;
+		goto out;
+	}
+
+	conn_do_handshake(conn);
+out:
+	return conn_destroy(conn);
+}
+
+/**
+ * quic_client_handshake - start a QUIC handshake with Certificate or PSK mode on client side
+ * @sockfd: IPPROTO_QUIC type socket
+ * @pkey_file: private key file (optional) or pre-shared key file
+ * @cert_file: certificate file (optional) or null
+ *
+ * Return values:
+ * - On success, 0.
+ * - On error, the error is returned.
+ */
+int quic_client_handshake(int sockfd, char *pkey_file, char *cert_file)
+{
+	struct quic_handshake_parms parms = {};
+	gnutls_pcert_st gcert;
+	int ret;
+
+	parms.timeout = 15000;
+	if (!cert_file) {
+		if (!pkey_file)
+			goto start;
+		ret = read_psk_file(pkey_file, parms.names, parms.keys);
+		if (ret <= 0) {
+			pr_error("parse psk file failed\n");
+			return -1;
+		}
+		parms.num_keys = ret;
+		goto start;
+	}
+
+	parms.cert = &gcert;
+	if (read_pkey_file(pkey_file, &parms.privkey) ||
+	    read_cert_file(cert_file, &parms.cert)) {
+		pr_error("parse prikey or cert files failed\n");
+		return -1;
+	}
+start:
+	return quic_client_handshake_parms(sockfd, &parms);
+}
+
+/**
+ * quic_server_handshake - start a QUIC handshake with Certificate or PSK mode on server side
+ * @sockfd: IPPROTO_QUIC type socket
+ * @pkey: private key file or pre-shared key file
+ * @cert: certificate file or null
+ *
+ * Return values:
+ * - On success, 0.
+ * - On error, the error is returned.
+ */
+int quic_server_handshake(int sockfd, char *pkey_file, char *cert_file)
+{
+	struct quic_handshake_parms parms = {};
+	gnutls_pcert_st gcert;
+	int ret;
+
+	parms.timeout = 15000;
+	if (!cert_file) {
+		ret = read_psk_file(pkey_file, parms.names, parms.keys);
+		if (ret <= 0) {
+			pr_error("parse psk file failed\n");
+			return -1;
+		}
+		parms.num_keys = ret;
+		goto start;
+	}
+
+	parms.cert = &gcert;
+	if (read_pkey_file(pkey_file, &parms.privkey) ||
+	    read_cert_file(cert_file, &parms.cert)) {
+		pr_error("parse prikey or cert files failed\n");
+		return -1;
+	}
+start:
+	return quic_server_handshake_parms(sockfd, &parms);
+}
+
+/**
+ * quic_recvmsg - receive msg and also get stream ID and flag
+ * @sockfd: IPPROTO_QUIC type socket
+ * @msg: msg buffer
+ * @len: msg buffer length
+ * @sid: stream ID got from kernel
+ * @flag: stream flag got from kernel
+ *
+ * Return values:
+ * - On success, the number of bytes received.
+ * - On error, -1 is returned, and errno is set to indicate the error.
+ */
+ssize_t quic_recvmsg(int sockfd, void *msg, size_t len, uint64_t *sid, uint32_t *flag)
+{
+	char incmsg[CMSG_SPACE(sizeof(struct quic_stream_info))];
+	struct quic_stream_info info;
+	struct cmsghdr *cmsg = NULL;
+	struct msghdr inmsg;
+	struct iovec iov;
+	int error;
+
+	memset(&inmsg, 0, sizeof(inmsg));
+
+	iov.iov_base = msg;
+	iov.iov_len = len;
+
+	inmsg.msg_name = NULL;
+	inmsg.msg_namelen = 0;
+	inmsg.msg_iov = &iov;
+	inmsg.msg_iovlen = 1;
+	inmsg.msg_control = incmsg;
+	inmsg.msg_controllen = sizeof(incmsg);
+
+	error = recvmsg(sockfd, &inmsg, 0);
+	if (error < 0)
+		return error;
+
+	if (!sid)
+		return error;
+
+	for (cmsg = CMSG_FIRSTHDR(&inmsg); cmsg != NULL; cmsg = CMSG_NXTHDR(&inmsg, cmsg))
+		if (IPPROTO_QUIC == cmsg->cmsg_level && QUIC_STREAM_INFO == cmsg->cmsg_type)
+			break;
+	if (cmsg) {
+		memcpy(&info, CMSG_DATA(cmsg), sizeof(struct quic_stream_info));
+		*sid = info.stream_id;
+		*flag = info.stream_flag;
+	}
+	return error;
+}
+
+/**
+ * quic_sendmsg - send msg with stream ID and flag
+ * @sockfd: IPPROTO_QUIC type socket
+ * @msg: msg to send
+ * @len: the length of the msg to send
+ * @sid: stream ID
+ * @flag: stream flag
+ *
+ * Return values:
+ * - On success, return the number of bytes sent.
+ * - On error, -1 is returned, and errno is set to indicate the error.
+ */
+ssize_t quic_sendmsg(int sockfd, const void *msg, size_t len, uint64_t sid, uint32_t flag)
+{
+	char outcmsg[CMSG_SPACE(sizeof(struct quic_stream_info))];
+	struct quic_stream_info *info;
+	struct msghdr outmsg;
+	struct cmsghdr *cmsg;
+	struct iovec iov;
+
+	outmsg.msg_name = NULL;
+	outmsg.msg_namelen = 0;
+	outmsg.msg_iov = &iov;
+	iov.iov_base = (void *)msg;
+	iov.iov_len = len;
+	outmsg.msg_iovlen = 1;
+
+	outmsg.msg_control = outcmsg;
+	outmsg.msg_controllen = sizeof(outcmsg);
+	outmsg.msg_flags = 0;
+
+	cmsg = CMSG_FIRSTHDR(&outmsg);
+	cmsg->cmsg_level = IPPROTO_QUIC;
+	cmsg->cmsg_type = 0;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(*info));
+
+	outmsg.msg_controllen = cmsg->cmsg_len;
+	info = (struct quic_stream_info *)CMSG_DATA(cmsg);
+	info->stream_id = sid;
+	info->stream_flag = flag;
+
+	return sendmsg(sockfd, &outmsg, 0);
+}

--- a/src/libquic/crypto.c
+++ b/src/libquic/crypto.c
@@ -1,0 +1,659 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* QUIC kernel implementation
+ * (C) Copyright Red Hat Corp. 2023
+ *
+ * This file is the userspace handshake part for the QUIC kernel implementation
+ *
+ * Initialization/cleanup for QUIC protocol support.
+ *
+ * Written or modified by:
+ *    Xin Long <lucien.xin@gmail.com>
+ */
+
+#include "libquic.h"
+
+#define QUIC_TLSEXT_QUIC_TRANSPORT_PARAMETERS_V1	0x39u
+#define ARRAY_SIZE(x)   (sizeof(x) / sizeof((x)[0]))
+
+static enum quic_crypto_level get_crypto_level(gnutls_record_encryption_level_t level)
+{
+	if (level == GNUTLS_ENCRYPTION_LEVEL_INITIAL)
+		return QUIC_CRYPTO_INITIAL;
+	if (level == GNUTLS_ENCRYPTION_LEVEL_HANDSHAKE)
+		return QUIC_CRYPTO_HANDSHAKE;
+	if (level == GNUTLS_ENCRYPTION_LEVEL_APPLICATION)
+		return QUIC_CRYPTO_APP;
+	if (level == GNUTLS_ENCRYPTION_LEVEL_EARLY)
+		return QUIC_CRYPTO_EARLY;
+	pr_warn("%s: %d\n", __func__, level);
+	return QUIC_CRYPTO_MAX;
+}
+
+static gnutls_record_encryption_level_t get_encryption_level(uint8_t level)
+{
+	if (level == QUIC_CRYPTO_INITIAL)
+		return GNUTLS_ENCRYPTION_LEVEL_INITIAL;
+	if (level == QUIC_CRYPTO_HANDSHAKE)
+		return GNUTLS_ENCRYPTION_LEVEL_HANDSHAKE;
+	if (level == QUIC_CRYPTO_APP)
+		return GNUTLS_ENCRYPTION_LEVEL_APPLICATION;
+	if (level == QUIC_CRYPTO_EARLY)
+		return GNUTLS_ENCRYPTION_LEVEL_EARLY;
+	pr_warn("%s: %d\n", __func__, level);
+	return QUIC_CRYPTO_MAX;
+}
+
+int quic_crypto_read_write_crypto_data(struct quic_conn *conn, uint8_t level,
+				       const uint8_t *data, size_t datalen)
+{
+	gnutls_session_t session = conn->session;
+	int rv;
+
+	level = get_encryption_level(level);
+	if (datalen > 0) {
+		rv = gnutls_handshake_write(session, level, data, datalen);
+		if (rv != 0) {
+			if (!gnutls_error_is_fatal(rv))
+				return 0;
+			goto err;
+		}
+	}
+
+	rv = gnutls_handshake(session);
+	if (rv < 0) {
+		if (!gnutls_error_is_fatal(rv))
+			return 0;
+		goto err;
+	}
+	return 0;
+err:
+	gnutls_alert_send_appropriate(session, rv);
+	pr_error("read write crypto data failed\n");
+	return rv;
+}
+
+static int dataum_copy(gnutls_datum_t *dest, const gnutls_datum_t *source)
+{
+	dest->data = malloc(source->size);
+	if (!dest->data)
+		return -ENOMEM;
+	memcpy(dest->data, source->data, source->size);
+	dest->size = source->size;
+	return 0;
+}
+
+static int client_x509_verify(gnutls_session_t session)
+{
+	struct quic_conn *conn = gnutls_session_get_ptr(session);
+	struct quic_handshake_parms *parms = conn->parms;
+	const gnutls_datum_t *peercerts;
+	unsigned int i, status;
+	int ret;
+
+	if (conn->cert_req == 3) /* no certificate verification */
+		return 0;
+	ret = gnutls_certificate_verify_peers3(session, parms->peername, &status);
+	if (ret != GNUTLS_E_SUCCESS || status)
+		return -1;
+
+	peercerts = gnutls_certificate_get_peers(session, &parms->num_keys);
+	if (!peercerts || !parms->num_keys)
+		return -1;
+	if (parms->num_keys > ARRAY_SIZE(parms->keys))
+		parms->num_keys = ARRAY_SIZE(parms->keys);
+	for (i = 0; i < parms->num_keys; i++) {
+		if (dataum_copy(&parms->keys[i], &peercerts[i]))
+			goto err;
+	}
+	return 0;
+err:
+	for (i = 0; i < parms->num_keys; i++) {
+		free(parms->keys[i].data);
+		parms->keys[i].size = 0;
+	}
+	return -1;
+}
+
+static int client_set_x509_cred(struct quic_conn *conn, void *cred)
+{
+	gnutls_privkey_t privkey = conn->parms->privkey;
+	gnutls_pcert_st  *cert = conn->parms->cert;
+
+	if (!privkey || !cert)
+		return 0;
+
+	return gnutls_certificate_set_key(cred, NULL, 0, cert, 1, privkey);
+}
+
+static uint32_t tls_cipher_type_get(gnutls_cipher_algorithm_t cipher)
+{
+	switch (cipher) {
+	case GNUTLS_CIPHER_AES_128_GCM:
+		return TLS_CIPHER_AES_GCM_128;
+	case GNUTLS_CIPHER_AES_128_CCM:
+		return TLS_CIPHER_AES_CCM_128;
+	case GNUTLS_CIPHER_AES_256_GCM:
+		return TLS_CIPHER_AES_GCM_256;
+	case GNUTLS_CIPHER_CHACHA20_POLY1305:
+		return TLS_CIPHER_CHACHA20_POLY1305;
+	default:
+		return 0;
+	}
+}
+
+static int secret_func(gnutls_session_t session,
+		       gnutls_record_encryption_level_t level,
+		       const void *rx_secret, const void *tx_secret, size_t secretlen)
+{
+	gnutls_cipher_algorithm_t type  = gnutls_cipher_get(session);
+	struct quic_conn *conn = gnutls_session_get_ptr(session);
+	struct quic_crypto_secret secret = {};
+	int len = sizeof(secret);
+
+	if (conn->completed)
+		return 0;
+
+	if (level == GNUTLS_ENCRYPTION_LEVEL_EARLY)
+		type = gnutls_early_cipher_get(session);
+
+	secret.level = get_crypto_level(level);
+	secret.type = tls_cipher_type_get(type);
+	if (tx_secret) {
+		secret.send = 1;
+		memcpy(secret.secret, tx_secret, secretlen);
+		if (setsockopt(conn->sockfd, SOL_QUIC, QUIC_SOCKOPT_CRYPTO_SECRET, &secret, len)) {
+			pr_error("socket setsockopt tx crypto_secret failed %d\n", level);
+			return -1;
+		}
+	}
+	if (rx_secret) {
+		secret.send = 0;
+		memcpy(secret.secret, rx_secret, secretlen);
+		if (setsockopt(conn->sockfd, SOL_QUIC, QUIC_SOCKOPT_CRYPTO_SECRET, &secret, len)) {
+			pr_error("socket setsockopt rx crypto_secret failed %d\n", level);
+			return -1;
+		}
+		if (secret.level == QUIC_CRYPTO_APP) {
+			if (conn->is_serv)
+				gnutls_session_ticket_send(session, 1, 0);
+			if (!conn->recv_ticket)
+				conn->completed = 1;
+		}
+	}
+	pr_debug("  %s: %d %d %d\n", __func__, secret.level, !!tx_secret, !!rx_secret);
+	return 0;
+}
+
+static int alert_read_func(gnutls_session_t session, gnutls_record_encryption_level_t gtls_level,
+			   gnutls_alert_level_t alert_level, gnutls_alert_description_t alert_desc)
+{
+	pr_warn("%s: %d\n", __func__, alert_desc);
+	return 0;
+}
+
+static int tp_recv_func(gnutls_session_t session, const uint8_t *buf, size_t len)
+{
+	struct quic_conn *conn = gnutls_session_get_ptr(session);
+
+	if (setsockopt(conn->sockfd, SOL_QUIC, QUIC_SOCKOPT_TRANSPORT_PARAM_EXT, buf, len)) {
+		pr_error("socket setsockopt transport_param_ext failed\n");
+		return -1;
+	}
+	return 0;
+}
+
+static int tp_send_func(gnutls_session_t session, gnutls_buffer_t extdata)
+{
+	struct quic_conn *conn = gnutls_session_get_ptr(session);
+	uint8_t buf[256];
+	unsigned int len;
+	int rv;
+
+	len = sizeof(buf);
+	if (getsockopt(conn->sockfd, SOL_QUIC, QUIC_SOCKOPT_TRANSPORT_PARAM_EXT, buf, &len)) {
+		pr_error("socket getsockopt transport_param_ext failed\n");
+		return -1;
+	}
+
+	rv = gnutls_buffer_append_data(extdata, buf, len);
+	if (rv != 0)
+		return -1;
+
+	return 0;
+}
+
+static int read_func(gnutls_session_t session, gnutls_record_encryption_level_t level,
+		     gnutls_handshake_description_t htype, const void *data, size_t datalen)
+{
+	struct quic_conn *conn = gnutls_session_get_ptr(session);
+	struct quic_frame *frame;
+	uint32_t len = datalen;
+
+	if (htype == GNUTLS_HANDSHAKE_KEY_UPDATE)
+		return 0;
+
+	while (len > 0) {
+		frame = malloc(sizeof(*frame));
+		memset(frame, 0, sizeof(*frame));
+		frame->data.buflen = len;
+		if (len > 1200)
+			frame->data.buflen = 1200;
+		memcpy(frame->data.buf, data, frame->data.buflen);
+
+		frame->level = get_crypto_level(level);
+		if (!conn->send_list)
+			conn->send_list = frame;
+		else
+			conn->send_last->next = frame;
+		conn->send_last = frame;
+
+		len -= frame->data.buflen;
+		data += frame->data.buflen;
+	}
+
+	pr_debug("  %s: %d %d %d\n", __func__, level, htype, datalen);
+	return 0;
+}
+
+static int crypto_gnutls_configure_session(gnutls_session_t session)
+{
+	gnutls_handshake_set_secret_function(session, secret_func);
+	gnutls_handshake_set_read_function(session, read_func);
+	gnutls_alert_set_read_function(session, alert_read_func);
+
+	return gnutls_session_ext_register(
+		session, "QUIC Transport Parameters",
+		QUIC_TLSEXT_QUIC_TRANSPORT_PARAMETERS_V1, GNUTLS_EXT_TLS, tp_recv_func,
+		tp_send_func, NULL, NULL, NULL,
+		GNUTLS_EXT_FLAG_TLS | GNUTLS_EXT_FLAG_CLIENT_HELLO | GNUTLS_EXT_FLAG_EE);
+}
+
+static char priority[] =
+	"%DISABLE_TLS13_COMPAT_MODE:NORMAL:-VERS-ALL:+VERS-TLS1.3:+PSK:-CIPHER-ALL:+";
+
+static char *get_priority(struct quic_conn *conn)
+{
+	char *p = (char *)conn->priority.data;
+
+	memcpy(p, priority, strlen(priority));
+	switch (conn->cipher) {
+	case TLS_CIPHER_AES_GCM_128:
+		strcat(p, "AES-128-GCM");
+		break;
+	case TLS_CIPHER_AES_GCM_256:
+		strcat(p, "AES-256-GCM");
+		break;
+	case TLS_CIPHER_AES_CCM_128:
+		strcat(p, "AES-128-CCM");
+		break;
+	case TLS_CIPHER_CHACHA20_POLY1305:
+		strcat(p, "CHACHA20-POLY1305");
+		break;
+	default:
+		strcat(p, "AES-128-GCM:+AES-256-GCM:+AES-128-CCM:+CHACHA20-POLY1305");
+		conn->cipher = 0;
+		break;
+	}
+	conn->priority.datalen = strlen(p) + 1;
+	return p;
+}
+
+static int session_ticket_recv(gnutls_session_t session, unsigned int htype, unsigned int when,
+			       unsigned int incoming, const gnutls_datum_t *msg)
+{
+	struct quic_conn *conn = gnutls_session_get_ptr(session);
+	gnutls_datum_t ticket;
+	int ret;
+
+	if (htype != GNUTLS_HANDSHAKE_NEW_SESSION_TICKET)
+		return 0;
+
+	conn->completed = 1;
+	ret = gnutls_session_get_data2(session, &ticket);
+	if (ret)
+		return ret;
+
+	ret = setsockopt(conn->sockfd, SOL_QUIC, QUIC_SOCKOPT_SESSION_TICKET,
+			 ticket.data, ticket.size);
+	if (ret) {
+		pr_debug("setsocket set session ticket %d\n", ticket.size);
+		return ret;
+	}
+	return 0;
+}
+
+static int session_set_alpns(gnutls_session_t session, char *data)
+{
+	char *alpn = strtok(data, ",");
+	gnutls_datum_t alpns[10];
+	int count = 0;
+
+	while (alpn) {
+		while (*alpn == ' ')
+			alpn++;
+
+		alpns[count].data = (unsigned char *)alpn;
+		alpns[count].size = strlen(alpn);
+		if (++count >= 10)
+			return -EINVAL;
+		alpn = strtok(NULL, ",");
+	}
+
+	gnutls_alpn_set_protocols(session, alpns, count, GNUTLS_ALPN_MANDATORY);
+	return 0;
+}
+
+int quic_crypto_client_set_x509_session(struct quic_conn *conn)
+{
+	gnutls_certificate_credentials_t cred;
+	gnutls_session_t session;
+	int ret;
+
+	ret = gnutls_certificate_allocate_credentials(&cred);
+	if (ret)
+		goto err;
+	if (conn->parms->cafile)
+		ret = gnutls_certificate_set_x509_trust_file(cred, conn->parms->cafile,
+							     GNUTLS_X509_FMT_PEM);
+	else
+		ret = gnutls_certificate_set_x509_system_trust(cred);
+	if (ret < 0)
+		goto err_cred;
+	ret = client_set_x509_cred(conn, cred);
+	if (ret)
+		goto err_cred;
+	gnutls_certificate_set_verify_function(cred, client_x509_verify);
+
+	ret = gnutls_init(&session, GNUTLS_CLIENT |
+				    GNUTLS_ENABLE_EARLY_DATA | GNUTLS_NO_END_OF_EARLY_DATA);
+	if (ret)
+		goto err_cred;
+	ret = gnutls_priority_set_direct(session, get_priority(conn), NULL);
+	if (ret)
+		goto err_session;
+	gnutls_handshake_set_hook_function(session, GNUTLS_HANDSHAKE_ANY,
+					   GNUTLS_HOOK_POST, session_ticket_recv);
+	gnutls_session_set_ptr(session, conn);
+	ret = crypto_gnutls_configure_session(session);
+	if (ret)
+		goto err_session;
+	if (conn->ticket.buflen) {
+		if (gnutls_session_set_data(session, conn->ticket.buf, conn->ticket.buflen))
+			goto err_session;
+	}
+	gnutls_credentials_set(session, GNUTLS_CRD_CERTIFICATE, cred);
+	if (conn->parms->peername)
+		gnutls_server_name_set(session, GNUTLS_NAME_DNS,
+				       conn->parms->peername, strlen(conn->parms->peername));
+	if (conn->alpn.datalen) {
+		ret = session_set_alpns(session, (char *)conn->alpn.data);
+		if (ret)
+			goto err_session;
+	}
+	conn->session = session;
+	return 0;
+err_session:
+	gnutls_deinit(session);
+err_cred:
+	gnutls_certificate_free_credentials(cred);
+err:
+	pr_error("session creation failed\n");
+	return ret;
+}
+
+static int client_set_psk_cred(struct quic_conn *conn, void *cred)
+{
+	gnutls_datum_t *key = &conn->parms->keys[0];
+	char *identity = conn->parms->names[0];
+
+	conn->parms->peername = identity;
+
+	return gnutls_psk_set_client_credentials(cred, identity, key, GNUTLS_PSK_KEY_RAW);
+}
+
+int quic_crypto_client_set_psk_session(struct quic_conn *conn)
+{
+	gnutls_psk_client_credentials_t cred;
+	gnutls_session_t session;
+	int ret;
+
+	ret = gnutls_psk_allocate_client_credentials(&cred);
+	if (ret)
+		goto err;
+	ret = client_set_psk_cred(conn, cred);
+	if (ret)
+		goto err_cred;
+
+	ret = gnutls_init(&session, GNUTLS_CLIENT);
+	if (ret)
+		goto err_cred;
+	ret = gnutls_priority_set_direct(session, get_priority(conn), NULL);
+	if (ret)
+		goto err_session;
+	gnutls_handshake_set_hook_function(session, GNUTLS_HANDSHAKE_ANY,
+					   GNUTLS_HOOK_POST, session_ticket_recv);
+	gnutls_session_set_ptr(session, conn);
+	ret = crypto_gnutls_configure_session(session);
+	if (ret)
+		goto err_session;
+	gnutls_credentials_set(session, GNUTLS_CRD_PSK, cred);
+	if (conn->alpn.datalen) {
+		ret = session_set_alpns(session, (char *)conn->alpn.data);
+		if (ret)
+			goto err_session;
+	}
+	conn->session = session;
+	return 0;
+err_session:
+	gnutls_deinit(session);
+err_cred:
+	gnutls_psk_free_client_credentials(cred);
+err:
+	pr_error("session creation failed\n");
+	return ret;
+}
+
+static int server_x509_verify(gnutls_session_t session)
+{
+	struct quic_conn *conn = gnutls_session_get_ptr(session);
+	struct quic_handshake_parms *parms = conn->parms;
+	const gnutls_datum_t *peercerts;
+	unsigned int i, status;
+	int ret;
+
+	ret = gnutls_certificate_verify_peers3(session, NULL, &status);
+	if (ret == GNUTLS_E_NO_CERTIFICATE_FOUND)
+		return 0;
+	if (ret != GNUTLS_E_SUCCESS || status)
+		return -1;
+
+	peercerts = gnutls_certificate_get_peers(session, &parms->num_keys);
+	if (!peercerts || !parms->num_keys)
+		return -1;
+	if (parms->num_keys > ARRAY_SIZE(parms->keys))
+		parms->num_keys = ARRAY_SIZE(parms->keys);
+	for (i = 0; i < parms->num_keys; i++) {
+		if (dataum_copy(&parms->keys[i], &peercerts[i]))
+			goto err;
+	}
+	return 0;
+err:
+	for (i = 0; i < parms->num_keys; i++) {
+		free(parms->keys[i].data);
+		parms->keys[i].size = 0;
+	}
+	return -1;
+}
+
+static int server_set_x509_cred(struct quic_conn *conn, void *cred)
+{
+	gnutls_privkey_t privkey = conn->parms->privkey;
+	gnutls_pcert_st  *cert = conn->parms->cert;
+
+	return gnutls_certificate_set_key(cred, NULL, 0, cert, 1, privkey);
+}
+
+static int server_alpn_verify(gnutls_session_t session, unsigned int htype, unsigned int when,
+			      unsigned int incoming, const gnutls_datum_t *msg)
+{
+	struct quic_conn *conn = gnutls_session_get_ptr(session);
+	gnutls_datum_t alpn = {};
+	int ret;
+
+	if (!conn->alpn.datalen)
+		return 0;
+
+	ret = gnutls_alpn_get_selected_protocol(session, &alpn);
+	if (ret)
+		return ret;
+	if (setsockopt(conn->sockfd, SOL_QUIC, QUIC_SOCKOPT_ALPN, alpn.data, alpn.size)) {
+		pr_error("socket setsockopt alpn failed %d\n", alpn.size);
+		return -1;
+	}
+	return 0;
+}
+
+static int anti_replay_db_add_func(void *dbf, time_t exp_time, const gnutls_datum_t *key,
+				   const gnutls_datum_t *data)
+{
+	return 0;
+}
+
+static gnutls_anti_replay_t anti_replay; /* TODO: make it per listen socket */
+
+int quic_crypto_server_set_x509_session(struct quic_conn *conn)
+{
+	gnutls_certificate_credentials_t cred;
+	gnutls_datum_t ticket_key;
+	gnutls_session_t session;
+	int ret;
+
+	ret = gnutls_certificate_allocate_credentials(&cred);
+	if (ret)
+		goto err;
+	if (conn->parms->cafile)
+		ret = gnutls_certificate_set_x509_trust_file(cred, conn->parms->cafile,
+							     GNUTLS_X509_FMT_PEM);
+	else
+		ret = gnutls_certificate_set_x509_system_trust(cred);
+	if (ret < 0)
+		goto err_cred;
+	ret = server_set_x509_cred(conn, cred);
+	if (ret)
+		goto err_cred;
+
+	gnutls_certificate_set_verify_function(cred, server_x509_verify);
+
+	conn->is_serv = 1;
+	ret = gnutls_init(&session, GNUTLS_SERVER | GNUTLS_NO_AUTO_SEND_TICKET |
+				    GNUTLS_ENABLE_EARLY_DATA | GNUTLS_NO_END_OF_EARLY_DATA);
+	if (ret)
+		goto err_cred;
+	ret = gnutls_priority_set_direct(session, get_priority(conn), NULL);
+	if (ret)
+		goto err_session;
+
+	if (!anti_replay) {
+		gnutls_anti_replay_init(&anti_replay);
+		gnutls_anti_replay_set_add_function(anti_replay, anti_replay_db_add_func);
+		gnutls_anti_replay_set_ptr(anti_replay, NULL);
+	}
+	gnutls_anti_replay_enable(session, anti_replay);
+	gnutls_record_set_max_early_data_size(session, 0xffffffffu);
+
+	gnutls_session_set_ptr(session, conn);
+	ret = crypto_gnutls_configure_session(session);
+	if (ret)
+		goto err_session;
+	ticket_key.data = conn->ticket.buf;
+	ticket_key.size = conn->ticket.buflen;
+	ret = gnutls_session_ticket_enable_server(session, &ticket_key);
+	if (ret)
+		goto err_session;
+	gnutls_handshake_set_hook_function(session, GNUTLS_HANDSHAKE_CLIENT_HELLO,
+					   GNUTLS_HOOK_POST, server_alpn_verify);
+	gnutls_credentials_set(session, GNUTLS_CRD_CERTIFICATE, cred);
+	gnutls_certificate_server_set_request(session, conn->cert_req);
+	if (conn->alpn.datalen) {
+		ret = session_set_alpns(session, (char *)conn->alpn.data);
+		if (ret)
+			goto err_session;
+	}
+
+	conn->session = session;
+	return 0;
+err_session:
+	gnutls_deinit(session);
+err_cred:
+	gnutls_certificate_free_credentials(cred);
+err:
+	pr_error("session creation failed\n");
+	return ret;
+}
+
+static int server_psk_verify(gnutls_session_t session, const char *username, gnutls_datum_t *key)
+{
+	struct quic_conn *conn = gnutls_session_get_ptr(session);
+	int i;
+
+	for (i = 0; i < conn->parms->num_keys; i++)
+		if (!strcmp(conn->parms->names[i], username))
+			break;
+	if (i == conn->parms->num_keys)
+		return -1;
+
+	conn->parms->peername = conn->parms->names[i];
+
+	if (dataum_copy(key, &conn->parms->keys[i]))
+		return -1;
+	return 0;
+}
+
+static int server_set_psk_cred(struct quic_conn *conn, void *cred)
+{
+	gnutls_psk_set_server_credentials_function(cred, server_psk_verify);
+	return 0;
+}
+
+int quic_crypto_server_set_psk_session(struct quic_conn *conn)
+{
+	gnutls_psk_server_credentials_t cred;
+	gnutls_session_t session;
+	int ret;
+
+	ret = gnutls_psk_allocate_server_credentials(&cred);
+	if (ret)
+		goto err;
+	ret = server_set_psk_cred(conn, cred);
+	if (ret)
+		goto err;
+
+	conn->is_serv = 1;
+	ret = gnutls_init(&session, GNUTLS_SERVER | GNUTLS_NO_AUTO_SEND_TICKET);
+	if (ret)
+		goto err_cred;
+	ret = gnutls_priority_set_direct(session, get_priority(conn), NULL);
+	if (ret)
+		goto err_session;
+	gnutls_session_set_ptr(session, conn);
+	ret = crypto_gnutls_configure_session(session);
+	if (ret)
+		goto err_session;
+	gnutls_handshake_set_hook_function(session, GNUTLS_HANDSHAKE_CLIENT_HELLO,
+					   GNUTLS_HOOK_POST, server_alpn_verify);
+	gnutls_credentials_set(session, GNUTLS_CRD_PSK, cred);
+	if (conn->alpn.datalen) {
+		ret = session_set_alpns(session, (char *)conn->alpn.data);
+		if (ret)
+			goto err_session;
+	}
+	conn->session = session;
+	return 0;
+err_session:
+	gnutls_deinit(session);
+err_cred:
+	gnutls_psk_free_server_credentials(cred);
+err:
+	pr_error("session creation failed\n");
+	return ret;
+}

--- a/src/libquic/libquic.h
+++ b/src/libquic/libquic.h
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* QUIC kernel implementation
+ * (C) Copyright Red Hat Corp. 2023
+ *
+ * This file is the userspace handshake part for the QUIC kernel implementation
+ *
+ * Initialization/cleanup for QUIC protocol support.
+ *
+ * Written or modified by:
+ *    Xin Long <lucien.xin@gmail.com>
+ */
+
+#include <gnutls/crypto.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <netinet/in.h>
+#include <linux/tls.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include "quic.h"
+
+#define MAX_BUFLEN	4096
+
+struct quic_buf {
+	uint32_t buflen;
+	uint8_t buf[MAX_BUFLEN];
+};
+
+struct quic_frame {
+	struct quic_frame *next;
+	struct quic_buf data;
+	uint8_t level;
+};
+
+struct quic_data {
+	uint8_t data[144];
+	uint32_t datalen;
+};
+
+struct quic_conn {
+	struct quic_handshake_parms *parms;
+	struct quic_data priority;
+	struct quic_data alpn;
+	uint32_t cipher;
+	int sockfd;
+
+	gnutls_session_t session;
+	struct quic_buf ticket;
+	uint8_t recv_ticket:1;
+	uint8_t completed:1;
+	uint8_t cert_req:2;
+	uint8_t is_serv:1;
+	uint8_t errcode;
+	timer_t timer;
+
+	struct quic_frame *send_list;
+	struct quic_frame *send_last;
+	struct quic_frame frame;
+};
+
+extern quic_log_func pr_error;
+extern quic_log_func pr_warn;
+extern quic_log_func pr_debug;
+
+int quic_crypto_read_write_crypto_data(struct quic_conn *conn, uint8_t encryption_level,
+				       const uint8_t *data, size_t datalen);
+int quic_crypto_client_set_x509_session(struct quic_conn *conn);
+int quic_crypto_server_set_x509_session(struct quic_conn *conn);
+int quic_crypto_client_set_psk_session(struct quic_conn *conn);
+int quic_crypto_server_set_psk_session(struct quic_conn *conn);

--- a/src/libquic/libquic.pc.in
+++ b/src/libquic/libquic.pc.in
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* QUIC kernel implementation
+ * (C) Copyright Red Hat Corp. 2023
+ *
+ * This file is the userspace handshake part for the QUIC kernel implementation
+ *
+ * Initialization/cleanup for QUIC protocol support.
+ *
+ * Written or modified by:
+ *    Xin Long <lucien.xin@gmail.com>
+ */
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: quic
+Description: User-level API library for in-kernel QUIC
+Version: 1.0
+Libs: -L${libdir} -lquic
+Cflags: -I${includedir}

--- a/src/libquic/quic.h
+++ b/src/libquic/quic.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* QUIC kernel implementation
+ * (C) Copyright Red Hat Corp. 2023
+ *
+ * This file is the userspace handshake part for the QUIC kernel implementation
+ *
+ * Initialization/cleanup for QUIC protocol support.
+ *
+ * Written or modified by:
+ *    Xin Long <lucien.xin@gmail.com>
+ */
+
+#include <gnutls/abstract.h>
+#include <sys/socket.h>
+#include <linux/quic.h>
+
+/* Socket option layer for QUIC */
+#ifndef SOL_QUIC
+#define SOL_QUIC		288
+#endif
+
+#ifndef IPPROTO_QUIC
+#define IPPROTO_QUIC		261
+#endif
+
+struct quic_handshake_parms {
+	uint32_t		timeout;	/* handshake timeout in milliseconds */
+
+	gnutls_privkey_t	privkey;	/* private key for x509 handshake */
+	gnutls_pcert_st		*cert;		/* certificate for x509 handshake */
+	char			*cafile;	/* system ca is used if not set */
+	char			*peername;	/* - server name for client side x509 handshake or,
+						 * - psk identity name chosen during PSK handshake
+						 */
+	char			*names[10];	/* psk identifies in PSK handshake */
+	gnutls_datum_t		keys[10];	/* - psk keys in PSK handshake, or,
+						 * - certificates received in x509 handshake
+						 */
+	uint32_t		num_keys;	/* keys total numbers */
+};
+
+int quic_client_handshake_parms(int sockfd, struct quic_handshake_parms *parms);
+int quic_server_handshake_parms(int sockfd, struct quic_handshake_parms *parms);
+
+int quic_client_handshake(int sockfd, char *pkey_file, char *cert_file);
+int quic_server_handshake(int sockfd, char *pkey_file, char *cert_file);
+
+ssize_t quic_sendmsg(int sockfd, const void *msg, size_t len, uint64_t sid, uint32_t flag);
+ssize_t quic_recvmsg(int sockfd, void *msg, size_t len, uint64_t *sid, uint32_t *flag);
+
+void quic_set_log_level(int level);
+typedef void (*quic_log_func)(char const *fmt, ...);
+void quic_set_log_funcs(quic_log_func debug, quic_log_func warn, quic_log_func error);

--- a/src/libquic/quic.man
+++ b/src/libquic/quic.man
@@ -1,0 +1,523 @@
+.TH QUIC  7 2024-01-15 "Linux Man Page" "Linux Programmer's Manual"
+.SH NAME
+quic \- QUIC protocol.
+.SH SYNOPSIS
+.nf
+.B #include <netinet/in.h>
+.B #include <netinet/quic.h>
+.sp
+.B quic_socket = socket(PF_INET, SOCK_STREAM, IPPROTO_QUIC);
+.B quic_socket = socket(PF_INET, SOCK_DGRAM, \ IPPROTO_QUIC);
+.fi
+.SH DESCRIPTION
+This is an implementation of the QUIC protocol as defined in RFC9000 (QUIC: A
+UDP-Based Multiplexed and Secure Transport). QUIC provides applications with
+flow-controlled streams for structured communication, low-latency connection
+establishment, and network path migration. QUIC includes security measures that
+ensure confidentiality, integrity, and availability in a range of deployment
+circumstances.
+
+.PP
+This implementation of QUIC in the kernel space enables users to utilize
+the QUIC protocol through common socket APIs in user space. Additionally,
+kernel subsystems like SMB and NFS can seamlessly operate over the QUIC
+protocol after handshake using net/handshake APIs.
+
+.PP
+In userspace, similar to TCP and SCTP, a typical server and client use the
+following system call sequence to communicate:
+.PP
+        Client				    Server
+     ------------------------------------------------------------------
+     sockfd = socket(IPPROTO_QUIC)      listenfd = socket(IPPROTO_QUIC)
+     bind(sockfd)                       bind(listenfd)
+                                        listen(listenfd)
+     connect(sockfd)
+     quic_client_handshake(sockfd)
+                                        sockfd = accecpt(listenfd)
+                                        quic_server_handshake(sockfd, cert)
+
+     sendmsg(sockfd)                    recvmsg(sockfd)
+     close(sockfd)                      close(sockfd)
+                                        close(listenfd)
+.PP
+On the client side, the connect() function initializes the keys and route, while
+quic_client_handshake() sends the initial packet to the server. Upon receiving the
+initial packet on the listen socket, the server creates a request socket, processes
+it through accept(), and subsequently generates a new common socket, returning it to
+the user. Meanwhile, the quic_server_handshake() function manages the reception and
+processing of the initial packet on the server, ensuring the handshake proceeds
+seamlessly until completion.
+
+.PP
+For kernel consumers, activating the tlshd service in userspace is essential. This
+service is responsible for receiving and managing kernel handshake requests for
+kernel sockets. Within the kernel space, the APIs mirror those used in userspace:
+
+        Client				    Server
+     ---------------------------------------------------------------------------
+     __sock_create(IPPROTO_QUIC, &sock)     __sock_create(IPPROTO_QUIC, &sock)
+     kernel_bind(sock)                      kernel_bind(sock)
+                                            kernel_listen(sock)
+     kernel_connect(sock)
+     tls_client_hello_x509(args:{sock})
+                                            kernel_accept(sock, &newsock)
+                                            tls_server_hello_x509(args:{newsock})
+
+     kernel_sendmsg(sock)                   kernel_recvmsg(newsock)
+     sock_release(sock)                     sock_release(newsock)
+                                            sock_release(sock)
+
+Please note that tls_client_hello_x509() and tls_server_hello_x509() are kernel APIs
+located in net/handshake/. These APIs are utilized to dispatch the handshake request
+to the userspace tlshd service and wait until the operation is successfully completed.
+
+.SH SYSCTLS
+These variables can be accessed by the
+.B /proc/sys/net/quic/*
+files or with the
+.BR sysctl (2)
+interface.  In addition, most IP sysctls also apply to QUIC. See
+.BR ip (7).
+Please check kernel documentation for this, at Documentation/networking/ip-sysctl.rst.
+.PP
+Upon loading the QUIC module, it also creates /proc/net/quic under procfs, enabling
+users to access and inspect information regarding existing QUIC connections.
+
+.SH SEND and RECEIVE MSGS
+The ancillary data is carried in msg_control field of struct msghdr, which is
+used in
+.B sendmsg(2)
+and
+.B recvmsg(2)
+call. The QUIC stack uses the ancillary data to communicate the attributes of
+the message stored in msg_iov to the socket. Each ancillary data item is preceded
+by a struct cmsghdr, see
+.B cmsg(3).
+.PP
+The cmsg type QUIC_STREAM_INFO is used to specify stream information for sendmsg()
+and describes stream information about a received message through recvmsg() with
+struct quic_stream_info:
+
+    struct quic_stream_info {
+        uint64_t stream_id;
+        uint32_t stream_flag;
+    };
+
+    - For stream_id, the first 2 bits are for the stream type for sending or receiving:
+
+      QUIC_STREAM_TYPE_SERVER_MASK: 0x1, server-side stream
+      QUIC_STREAM_TYPE_UNI_MASK: 0x2, unidirectional stream
+
+    - For stream_flag, sending flag includes:
+
+      QUIC_STREAM_FLAG_NEW: open a stream and send the first data
+      QUIC_STREAM_FLAG_FIN: send the last data and close a stream
+      QUIC_STREAM_FLAG_DATAGRAM: send data as datagram
+
+      and receiving flag includes:
+
+      QUIC_STREAM_FLAG_NOTIFICATION: data received is an event
+      QUIC_STREAM_FLAG_FIN: data received is the last one for this stream
+      QUIC_STREAM_FLAG_DATAGRAM: data received is datagram
+
+All these related macros and structures are defined in /usr/include/netinet/quic.h.
+
+.PP
+There are two APIs wrapped for sending and receiving msgs with stream information:
+.nf
+.sp
+.B quic_sendmsg(int sockfd, const void *msg, size_t len, uint64_t sid, uint32_t flag)
+.B quic_recvmsg(int sockfd, void *msg, size_t len, uint64_t *sid, uint32_t *flag)
+.sp
+.fi
+where sid is equivalent to stream_id while flag is equivalent to stream_flag in
+struct quic_stream_info above.
+
+.PP
+If one wants to use send() and recv() to send and receive msgs, some equivalent
+flags are provided:
+
+    - recv():
+
+      MSG_NOTIFICATION
+      MSG_FIN
+      MSG_DATAGRAM
+
+    - send():
+
+      MSG_SYN [ | MSG_STREAM_UNI]
+      MSG_FIN
+      MSG_DATAGRAM
+
+However, as stream_id can not be passed into kernel without cmsg, send() with
+MSG_SYN will open the next available stream, with MSG_STREAM_UNI to set the
+stream type to unidirectional.
+
+.SH HANDSHAKE APIS
+The implementation uses the sendmsg() and recvmsg() with the cmsg type
+QUIC_HANDSHAKE_INFO to send and receive raw TLS messages from or to kernel and
+exchange them in userspace via TLS library like gnutls. Meanwhile, they use some
+socket options to get necessary information like Transport Parameters from kernel
+to build TLS messages, and set secrets derived for different levels to kernel for
+QUIC packets encryption and decryption.
+
+.PP
+These are two common handshake APIs:
+.nf
+.sp
+.B int quic_client_handshake(int sockfd, char *pkey_file, char *cert_file);
+.B int quic_server_handshake(int sockfd, char *pkey_file, char *cert_file);
+.sp
+.fi
+
+- PSK mode:
+
+   pkey_file: psk file name
+   cert_file: null
+
+- Certificate mode:
+
+   pkey_file: private key file name, can be null for client
+   cert_file: certificate file name, can be null for client
+
+These functions return 0 for success and errcode in case of an error.
+
+.PP
+and another two advanced handshake APIs with more TLS Handshake Parameters:
+.nf
+.sp
+.B int quic_client_handshake_parms(int sockfd, struct quic_handshake_parms *parms);
+.B int quic_server_handshake_parms(int sockfd, struct quic_handshake_parms *parms);
+.sp
+.fi
+
+struct quic_handshake_parms members are described below:
+
+    struct quic_handshake_parms {
+        uint32_t           timeout;    /* handshake timeout in milliseconds */
+
+        gnutls_privkey_t   privkey;    /* private key for x509 handshake */
+        gnutls_pcert_st    *cert;      /* certificate for x509 handshake */
+	char               *cafile;    /* system ca is used if not set */
+        char               *peername;  /* - server name for client side x509 handshake or,
+                                        * - psk identity name chosen during PSK handshake
+                                        */
+        char               *names[10]; /* psk identifies in PSK handshake */
+        gnutls_datum_t     keys[10];   /* - psk keys in PSK handshake, or,
+                                        * - certificates received in x509 handshake
+                                        */
+        uint32_t           num_keys;   /* keys total numbers */
+    };
+
+These functions return 0 for success and errcode in case of an error. Currently it's
+used by tlshd service for Kernel Consumer handshake request.
+
+.SH EVENTS and NOTIFICATIONS
+An QUIC application may need to understand and process events and errors that happen
+on the QUIC stack. These events include stream updates and max_streams, connection
+close and migration, key updates, new token. When a notification arrives, recvmsg()
+returns the notification in the application-supplied data buffer via msg_iov, and
+sets MSG_NOTIFICATION in msg_flags of msghdr and QUIC_STREAM_FLAG_NOTIFICATION in
+stream_flags of cmsg quic_stream_info. See QUIC_EVENT socket option for the event
+enabling. The different events are listed below, and all these related macros and
+structures are defined in /usr/include/netinet/quic.h.
+
+.TP
+.B QUIC_EVENT_STREAM_UPDATE:
+Only the notification with one of these states is sent to userspace:
+
+    QUIC_STREAM_SEND_STATE_RECVD
+    QUIC_STREAM_SEND_STATE_RESET_SENT:  only if STOP_SENDING is received
+    QUIC_STREAM_SEND_STATE_RESET_RECVD
+    QUIC_STREAM_RECV_STATE_RECV:        only when the last frag hasn't arrived.
+    QUIC_STREAM_RECV_STATE_SIZE_KNOWN:  only if data comes out of order
+    QUIC_STREAM_RECV_STATE_RECVD
+    QUIC_STREAM_RECV_STATE_RESET_RECVD
+
+Data format in the event:
+
+    struct quic_stream_update {
+        uint64_t id;
+        uint32_t state;
+        uint32_t errcode; /* or known_size */
+    };
+
+.TP
+.B QUIC_EVENT_STREAM_MAX_STREAM:
+This notification is created when max_streams frame is received, and this is useful
+when using QUIC_STREAM_FLAG_ASYNC to open a stream whose id exceeds the max stream
+count. After receiving this notification, try to open this stream again.
+
+Data format in the event:
+
+    uint64_t max_stream;
+
+.TP
+.B QUIC_EVENT_CONNECTION_CLOSE
+This notification is created when receiving a close frame from peer where it can set
+the close info with QUIC_SOCKOPT_CONNECTION_CLOSE socket option.
+
+Data format in the event:
+
+    struct quic_connection_close {
+        uint32_t errcode;
+        uint8_t frame;
+        uint8_t phrase[];
+    };
+
+.TP
+.B QUIC_EVENT_CONNECTION_MIGRATION
+This notification is created when either side successfully changes its source address
+by QUIC_SOCKOPT_CONNECTION_MIGRATION socket option or its dest address by the same
+socket option called by peer. The parameter tells you if it is a local or peer
+connection migration and then you can get the new address with getsockname() or
+getpeername().
+
+Data format in the event:
+
+    uint8_t local_migration;
+
+.TP
+.B QUIC_EVENT_KEY_UPDATE
+This notification is created when both sides have used the new key after key update,
+and the parameter tells you which the new key phase is.
+
+Data format in the event:
+
+    uint8_t key_update_phase;
+
+.TP
+.B QUIC_EVENT_NEW_TOKEN
+Since the handshake is in userspace, this notification is created whenever the
+frame of NEW_TOKEN is received from the peer where it can send these frame via
+QUIC_SOCKOPT_NEW_TOKEN socket option.
+
+Data format in the event:
+
+    uint8_t *token;
+
+.SH "SOCKET OPTIONS"
+To set or get a QUIC socket option, call
+.BR getsockopt (2)
+to read or
+.BR setsockopt (2)
+to write the option with the option level argument set to
+.BR SOL_QUIC.
+Note that all these macros and structures described for parameters are defined
+in /usr/include/linux/quic.h.
+.TP
+.B QUIC_SOCKOPT_STREAM_OPEN
+This option is used to open a stream.
+
+For reading only, and the parameter type is:
+
+    struct quic_stream_info {
+        uint64_t stream_id;
+        uint32_t stream_flag;
+    };
+
+stream_id can be set to:
+
+    >= 0: open a stream with a specific stream id.
+    -1:  open next available stream and return the stream id to users via stream_id.
+
+stream_flag can be set to:
+
+    QUIC_STREAM_FLAG_UNI: open the next unidirectional stream
+    QUIC_STREAM_FLAG_ASYNC: open the stream without block
+
+.TP
+.B QUIC_SOCKOPT_STREAM_RESET
+This option is used to reset a stream and it means that the endpoint will not
+guarantee delivery of stream data.
+
+For writing only, and the parameter type is:
+
+    struct quic_errinfo {
+        uint64_t stream_id;
+        uint32_t errcode;
+    };
+
+errcode is Application Protocol Error Code left to application protocols.
+
+.TP
+.B QUIC_SOCKOPT_STREAM_STOP_SENDING
+This option is used to request that a peer cease transmission on a stream.
+
+For writing only, and the parameter type is:
+
+    struct quic_errinfo {
+        uint64_t stream_id;
+        uint32_t errcode;
+    };
+
+errcode is Application Protocol Error Code left to application protocols.
+
+.TP
+.B QUIC_SOCKOPT_CONNECTION_MIGRATION
+This option is used to initiate a connection migration. It can also be used to
+set preferred_address transport param before handshake on server side.
+
+For writing only, and the parameter type is:
+
+    struct sockaddr_in or struct sockaddr_in6.
+
+to tell kernel the new local address to bind.
+
+.TP
+.B QUIC_SOCKOPT_KEY_UPDATE
+This option is used to initiate a key update or rekeying.
+
+For writing only, and the parameter type is
+
+    null.
+
+.TP
+.BR QUIC_SOCKOPT_EVENT
+This option is used to enable or disable one type of event or notification.
+
+For reading and writing, and the parameter type is:
+
+    struct quic_event_option {
+        uint8_t type;
+        uint8_t on;
+    };
+
+See
+.BR EVENTS and NOTIFICATIONS
+for type, on is 1 to enable and 0 to disable, all events are disabled by default.
+
+.TP
+.B QUIC_SOCKOPT_CONNECTION_CLOSE
+This option is used to get or get the close context, which includes errcode and
+phrase and frame. On close side, set it before calling close() to tell peer the
+closing info, while on being closed side get it to show the peer closing info.
+
+For reading and writing, and the parameter type is:
+
+    struct quic_connection_close {
+        uint32_t errcode;
+        uint8_t frame;
+        uint8_t phrase[];
+    };
+
+errcode is Application Protocol Error Code left to application protocols, phrase
+is a string to describe more details, frame is the frame type that caused the
+closing. All three are 0 or null by default.
+
+.TP
+.B QUIC_SOCKOPT_TRANSPORT_PARAM
+This option is used to configure the transport parameters, including not only
+the quic original transport param, but also some handshake options.
+
+For reading and writing, and the parameter type is:
+
+    struct quic_transport_param {
+        uint8_t     remote;
+        uint8_t     disable_active_migration; (0 by default)
+        uint8_t     grease_quic_bit; (0)
+        uint8_t     stateless_reset; (0)
+        uint8_t     disable_1rtt_encryption; (0)
+        uint8_t     disable_compatible_version; (0)
+        uint64_t    max_udp_payload_size; (65527)
+        uint64_t    ack_delay_exponent; (3)
+        uint64_t    max_ack_delay; (25000)
+        uint64_t    active_connection_id_limit; (7)
+        uint64_t    max_idle_timeout; (30000000 us)
+        uint64_t    max_datagram_frame_size; (0)
+        uint64_t    max_data; (sk_rcvbuf / 2)
+        uint64_t    max_stream_data_bidi_local; (sk_rcvbuf / 4)
+        uint64_t    max_stream_data_bidi_remote; (sk_rcvbuf / 4)
+        uint64_t    max_stream_data_uni; (sk_rcvbuf / 4)
+        uint64_t    max_streams_bidi; (100)
+        uint64_t    max_streams_uni; (100)
+        uint64_t    initial_smoothed_rtt; (333000)
+
+        uint32_t    plpmtud_probe_timeout; (0)
+        uint8_t     validate_peer_address; (0)
+        uint8_t     receive_session_ticket; (0)
+        uint8_t     certificate_request; (0)
+        uint8_t     congestion_control_alg; (QUIC_CONG_ALG_RENO)
+        uint32_t    payload_cipher_type; (0)
+        uint32_t    version; (QUIC_VERSION_V1)
+    };
+
+These members in the 1st group are from RFC9000, and in the 2nd group, the members are:
+
+    - plpmtud_probe_timeout: plpmtud probe timeout in usec, 0: disabled
+    - validate_peer_address: for server only, verify token and send retry packet
+    - receive_session_ticket: for client only, handshake done until ticket is recvd
+    - certificate_request: for server, 0: IGNORE 1: REQUEST 2: REQUIRE
+                           for client, 3: NO CERTIFICATE VALIDATION
+    - congestion_control_alg: congestion control algorithm
+    - payload_cipher_type: AES_GCM_128/AES_GCM_256/AES_CCM_128/CHACHA20_POLY1305
+    - version:  QUIC_VERSION_V1 or V2 for now
+
+See inline notes for default values.
+
+Note 'remote' member allows users to set remote transport parameter. Together with
+the session resumption ticket, it is used to set the remote transport parameter
+from last connection before sending 0-RTT DATA.
+
+.TP
+.B QUIC_SOCKOPT_TOKEN
+On Client this option is used to set regular token, which is used for the peer
+server's address verification. The token is usually issued by peer from the last
+connection and got via setsockopt with this option or QUIC_EVENT_NEW_TOKEN event.
+
+On Server this option is used to issue the token to Client for the next connection's
+address verification
+
+For reading and writing, and the parameter type is:
+
+    uint8_t *opt for client, or null for server.
+
+The default value in socket is null.
+
+.TP
+.B QUIC_SOCKOPT_ALPN
+This option is used to set or get the Application-Layer Protocol Negotiation before
+handshake, multiple ALPNs are separated by ',' e.g. "smbd, h3, ksmbd".
+
+On server side, during handshake it gets ALPN via this socket option and matches
+the ALPN from the client side, and then sets the matched ALPN to the socket, so
+that users can get the selected ALPN via this socket option after handshake.
+
+Note ALPN matching within the kernel is also supported, which directs incoming
+requests to relevant applications across different processes based on ALPN.
+
+For reading and writing, and the parameter type is:
+
+    char *alpn.
+
+The default value is null.
+
+.TP
+.B QUIC_SOCKOPT_SESSION_TICKET
+This option is used to set session resumption ticket on Client, which is used for
+session resumption. The ticket is usually issued by peer from the last connection
+and got via setsockopt with this option.
+
+For reading and writing, and the parameter type is:
+
+    uint8_t *opt for client, or null for server.
+
+The default value is null.
+
+.SH AUTHORS
+Xin Long <lucien.xin@gmail.com>
+.SH "SEE ALSO"
+.BR socket (7),
+.BR socket (2),
+.BR ip (7),
+.BR bind (2),
+.BR listen (2),
+.BR accept (2),
+.BR connect (2),
+.BR sendmsg (2),
+.BR recvmsg (2),
+.BR sysctl (2),
+.BR getsockopt (2),
+.sp
+RFC9000 for the QUIC specification.

--- a/src/tlshd/Makefile.am
+++ b/src/tlshd/Makefile.am
@@ -24,10 +24,11 @@ EXTRA_DIST		= $(man5_MANS) $(man8_MANS)
 
 sbin_PROGRAMS		= tlshd
 tlshd_CFLAGS		= -Werror -Wall -Wextra $(LIBGNUTLS_CFLAGS) \
-			  $(LIBKEYUTILS_CFLAGS) $(GLIB_CFLAGS) $(LIBNL3_CFLAGS)
+			  $(LIBKEYUTILS_CFLAGS) $(GLIB_CFLAGS) $(LIBNL3_CFLAGS) \
+			  $(LIBQUIC_CFLAGS)
 tlshd_SOURCES		= client.c config.c handshake.c keyring.c ktls.c log.c \
 			  main.c netlink.c netlink.h server.c tlshd.h
 tlshd_LDADD		= $(LIBGNUTLS_LIBS) $(LIBKEYUTILS_LIBS) $(GLIB_LIBS) \
-			  $(LIBNL3_LIBS) -lnl-genl-3
+			  $(LIBNL3_LIBS) -lnl-genl-3 $(LIBQUIC_LIBS)
 
 MAINTAINERCLEANFILES	= Makefile.in cscope.out


### PR DESCRIPTION
In this patchset, it introduces libquic in patch 1/3, and implements quic handshake in tlshd via the handshake APIs from libquic in patch 2/3, and adds 'enable_quic' option in configure.ac to allow users to enable quic handshake in patch 3/3.

A basic test can be done with the steps below:

1. build and install quic module, and generate ca/cert/pkey/psk for testing:

```
  # cd /home/lxin
  # git clone https://github.com/lxin/quic.git
  # cd quic
  # make
  # sudo make install

  # cd tests/keys
  # ./ca_cert_pkey_psk.sh
```

2. build tlshd with this patchset, and configure tlshd and start it:

```
  # cd /home/lxin
  (clone ktls-utils repo and apply this patchset)
  # ./autogen.sh
  # ./configure --with-systemd --enable-quic
  # make
  # sudo make install

  # sudo install -m 644 src/tlshd/tlshd.conf /etc/tlshd.conf
    (make install doesn't install tlshd.conf to /etc on Ubuntu somehow)
  # sudo vim /etc/tlshd.conf
  ...
  [authenticate]
  keyrings=quic

  [authenticate.client]
  x509.truststore= /home/lxin/quic/tests/keys/ca-cert.pem
  x509.certificate=/home/lxin/quic/tests/keys/client-cert.pem
  x509.private_key=/home/lxin/quic/tests/keys/client-key.pem

  [authenticate.server]
  x509.truststore= /home/lxin/quic/tests/keys/ca-cert.pem
  x509.certificate=/home/lxin/quic/tests/keys/server-cert.pem
  x509.private_key=/home/lxin/quic/tests/keys/server-key.pem

  # sudo systemctl restart tlshd
```

3. test it from kernel to userspace and userspace to kernel:

```
  # cd /home/lxin
  # cd quic/tests
  # make
```

  - kernel -> userspace (X509)
```
    # ./perf_test -l --ca ./keys/ca-cert.pem \
                     --pkey ./keys/server-key.pem \
                     --cert ./keys/server-cert.pem
    # sudo modprobe quic_sample_test role=client
      (in another terminal)
    # sudo dmesg
    # sudo rmmod quic_sample_test
    # pkill perf_test
```

  - userspace -> kernel (X509)
```
    # sudo modprobe quic_sample_test role=server
    # ./perf_test --addr 127.0.0.1 --ca ./keys/ca-cert.pem
      (in another terminal)
    # sudo rmmod quic_sample_test
    # pkill perf_test
```
  - kernel -> userspace (PSK)
```
    # ./perf_test -l --psk ./keys/server-psk.txt
    # PSK=`keyctl show @u |grep test1 |awk '{print $1}'`
    # sudo modprobe quic_sample_test role=client psk=$PSK
      (in another terminal)
    # sudo dmesg
    # sudo rmmod quic_sample_test
    # pkill perf_test
```

  - userspace -> kernel (PSK)
```
    # sudo modprobe quic_sample_test role=server psk=1
    # ./perf_test --addr 127.0.0.1 --psk ./keys/client-psk.txt
      (in another terminal)
    # sudo rmmod quic_sample_test
    # pkill perf_test
```