### PR TITLE
tlshd: add support for quic handshake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,10 @@ PKG_CHECK_MODULES([LIBNL3], libnl-3.0 >= 3.1)
 AC_SUBST([LIBNL3_CFLAGS])
 AC_SUBST([LIBNL3_LIBS])
 
+AC_CHECK_FILE([/usr/include/linux/quic.h],
+              [AC_CHECK_LIB([gnutls], [gnutls_handshake_set_secret_function],
+                            [AC_DEFINE([HAVE_GNUTLS_QUIC], [1], [Define to 1 if QUIC is found.])])])
+
 AC_CHECK_LIB([gnutls], [gnutls_transport_is_ktls_enabled],
              [AC_DEFINE([HAVE_GNUTLS_TRANSPORT_IS_KTLS_ENABLED], [1],
                         [Define to 1 if you have the gnutls_transport_is_ktls_enabled function.])])

--- a/src/tlshd/Makefile.am
+++ b/src/tlshd/Makefile.am
@@ -26,7 +26,7 @@ sbin_PROGRAMS		= tlshd
 tlshd_CFLAGS		= -Werror -Wall -Wextra $(LIBGNUTLS_CFLAGS) \
 			  $(LIBKEYUTILS_CFLAGS) $(GLIB_CFLAGS) $(LIBNL3_CFLAGS)
 tlshd_SOURCES		= client.c config.c handshake.c keyring.c ktls.c log.c \
-			  main.c netlink.c netlink.h server.c tlshd.h
+			  main.c netlink.c netlink.h server.c tlshd.h quic.c
 tlshd_LDADD		= $(LIBGNUTLS_LIBS) $(LIBKEYUTILS_LIBS) $(GLIB_LIBS) \
 			  $(LIBNL3_LIBS) -lnl-genl-3
 

--- a/src/tlshd/handshake.c
+++ b/src/tlshd/handshake.c
@@ -138,10 +138,34 @@ void tlshd_service_socket(void)
 
 	switch (parms.handshake_type) {
 	case HANDSHAKE_MSG_TYPE_CLIENTHELLO:
-		tlshd_tls13_clienthello_handshake(&parms);
+		switch (parms.ip_proto) {
+		case IPPROTO_TCP:
+			tlshd_tls13_clienthello_handshake(&parms);
+			break;
+#ifdef HAVE_GNUTLS_QUIC
+		case IPPROTO_QUIC:
+			tlshd_quic_clienthello_handshake(&parms);
+			break;
+#endif
+		default:
+			tlshd_log_debug("Unsupported ip_proto (%d)", parms.ip_proto);
+			parms.session_status = EOPNOTSUPP;
+		}
 		break;
 	case HANDSHAKE_MSG_TYPE_SERVERHELLO:
-		tlshd_tls13_serverhello_handshake(&parms);
+		switch (parms.ip_proto) {
+		case IPPROTO_TCP:
+			tlshd_tls13_serverhello_handshake(&parms);
+			break;
+#ifdef HAVE_GNUTLS_QUIC
+		case IPPROTO_QUIC:
+			tlshd_quic_serverhello_handshake(&parms);
+			break;
+#endif
+		default:
+			tlshd_log_debug("Unsupported ip_proto (%d)", parms.ip_proto);
+			parms.session_status = EOPNOTSUPP;
+		}
 		break;
 	default:
 		tlshd_log_debug("Unrecognized handshake type (%d)",

--- a/src/tlshd/netlink.c
+++ b/src/tlshd/netlink.c
@@ -237,6 +237,7 @@ static int tlshd_genl_valid_handler(struct nl_msg *msg, void *arg)
 	struct nlattr *tb[HANDSHAKE_A_ACCEPT_MAX + 1];
 	struct tlshd_handshake_parms *parms = arg;
 	char *peername = NULL;
+	socklen_t optlen;
 	int err;
 
 	tlshd_log_debug("Parsing a valid netlink message\n");
@@ -253,6 +254,12 @@ static int tlshd_genl_valid_handler(struct nl_msg *msg, void *arg)
 		if (getpeername(parms->sockfd, parms->peeraddr,
 				&parms->peeraddr_len) == -1) {
 			tlshd_log_perror("getpeername");
+			return NL_STOP;
+		}
+		optlen = sizeof(parms->ip_proto);
+		if (getsockopt(parms->sockfd, SOL_SOCKET, SO_PROTOCOL,
+			       &parms->ip_proto, &optlen) == -1) {
+			tlshd_log_perror("getsockopt (SO_PROTOCOL)");
 			return NL_STOP;
 		}
 	}
@@ -288,6 +295,7 @@ static const struct tlshd_handshake_parms tlshd_default_handshake_parms = {
 	.peeraddr		= (struct sockaddr *)&tlshd_peeraddr,
 	.peeraddr_len		= sizeof(tlshd_peeraddr),
 	.sockfd			= -1,
+	.ip_proto		= -1,
 	.handshake_type		= HANDSHAKE_MSG_TYPE_UNSPEC,
 	.timeout_ms		= GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT,
 	.auth_mode		= HANDSHAKE_AUTH_UNSPEC,

--- a/src/tlshd/quic.c
+++ b/src/tlshd/quic.c
@@ -1,0 +1,621 @@
+/*
+ * Perform a QUIC server or client side handshake.
+ *
+ * Copyright (c) 2024 Red Hat, Inc.
+ *
+ * ktls-utils is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include <gnutls/abstract.h>
+#include <sys/socket.h>
+#include <linux/tls.h>
+#include <keyutils.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <glib.h>
+
+#include "config.h"
+#include "tlshd.h"
+
+#ifdef HAVE_GNUTLS_QUIC
+static void quic_timer_handler(union sigval arg)
+{
+	struct tlshd_quic_conn *conn = arg.sival_ptr;
+
+	tlshd_log_error("conn timeout error %d", ETIMEDOUT);
+	conn->errcode = ETIMEDOUT;
+}
+
+static int quic_set_nonblocking(int sockfd, uint8_t nonblocking)
+{
+	int flags = fcntl(sockfd, F_GETFL, 0);
+
+	if (flags == -1) {
+		tlshd_log_error("socket fcntl getfl error %d", errno);
+		return -1;
+	}
+
+	if (nonblocking)
+		flags |= O_NONBLOCK;
+	else
+		flags &= ~O_NONBLOCK;
+
+	if (fcntl(sockfd, F_SETFL, flags) == -1) {
+		tlshd_log_error("socket fcntl setfl error %d %d", errno, flags);
+		return -1;
+	}
+	return 0;
+}
+
+static int quic_conn_setup_timer(struct tlshd_quic_conn *conn)
+{
+	uint64_t msec = conn->parms->timeout_ms;
+	struct itimerspec its = {};
+	struct sigevent sev = {};
+
+	if (quic_set_nonblocking(conn->parms->sockfd, 1))
+		return -1;
+
+	sev.sigev_notify = SIGEV_THREAD;
+	sev.sigev_notify_function = quic_timer_handler;
+	sev.sigev_value.sival_ptr = conn;
+	if (timer_create(CLOCK_REALTIME, &sev, &conn->timer)) {
+		tlshd_log_error("timer creation error %d", errno);
+		return -1;
+	}
+
+	its.it_value.tv_sec  = msec / 1000;
+	its.it_value.tv_nsec = (msec % 1000) * 1000000;
+	if (timer_settime(conn->timer, 0, &its, NULL)) {
+		tlshd_log_error("timer setup error %d", errno);
+		return -1;
+	}
+	return 0;
+}
+
+static void quic_conn_delete_timer(struct tlshd_quic_conn *conn)
+{
+	quic_set_nonblocking(conn->parms->sockfd, 0);
+	timer_delete(conn->timer);
+}
+
+static uint32_t quic_get_tls_cipher_type(gnutls_cipher_algorithm_t cipher)
+{
+	switch (cipher) {
+	case GNUTLS_CIPHER_AES_128_GCM:
+		return TLS_CIPHER_AES_GCM_128;
+	case GNUTLS_CIPHER_AES_128_CCM:
+		return TLS_CIPHER_AES_CCM_128;
+	case GNUTLS_CIPHER_AES_256_GCM:
+		return TLS_CIPHER_AES_GCM_256;
+	case GNUTLS_CIPHER_CHACHA20_POLY1305:
+		return TLS_CIPHER_CHACHA20_POLY1305;
+	default:
+		tlshd_log_notice("%s: %d", __func__, cipher);
+		return 0;
+	}
+}
+
+static enum quic_crypto_level quic_get_crypto_level(gnutls_record_encryption_level_t level)
+{
+	switch (level) {
+	case GNUTLS_ENCRYPTION_LEVEL_INITIAL:
+		return QUIC_CRYPTO_INITIAL;
+	case GNUTLS_ENCRYPTION_LEVEL_HANDSHAKE:
+		return QUIC_CRYPTO_HANDSHAKE;
+	case GNUTLS_ENCRYPTION_LEVEL_APPLICATION:
+		return QUIC_CRYPTO_APP;
+	case GNUTLS_ENCRYPTION_LEVEL_EARLY:
+		return QUIC_CRYPTO_EARLY;
+	default:
+		tlshd_log_notice("%s: %d", __func__, level);
+		return QUIC_CRYPTO_MAX;
+	}
+}
+
+static int quic_secret_func(gnutls_session_t session, gnutls_record_encryption_level_t level,
+			    const void *rx_secret, const void *tx_secret, size_t secretlen)
+{
+	struct tlshd_quic_conn *conn = gnutls_session_get_ptr(session);
+	gnutls_cipher_algorithm_t type  = gnutls_cipher_get(session);
+	struct quic_crypto_secret secret = {};
+	int sockfd, ret, len = sizeof(secret);
+
+	if (conn->completed)
+		return 0;
+
+	if (level == GNUTLS_ENCRYPTION_LEVEL_EARLY)
+		type = gnutls_early_cipher_get(session);
+
+	sockfd = conn->parms->sockfd;
+	secret.level = quic_get_crypto_level(level);
+	secret.type = quic_get_tls_cipher_type(type);
+	if (tx_secret) {
+		secret.send = 1;
+		memcpy(secret.secret, tx_secret, secretlen);
+		if (setsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_CRYPTO_SECRET, &secret, len)) {
+			tlshd_log_error("socket setsockopt tx secret error %d %u", errno, level);
+			return -1;
+		}
+	}
+	if (rx_secret) {
+		secret.send = 0;
+		memcpy(secret.secret, rx_secret, secretlen);
+		if (setsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_CRYPTO_SECRET, &secret, len)) {
+			tlshd_log_error("socket setsockopt rx secret error %d %u", errno, level);
+			return -1;
+		}
+		if (secret.level == QUIC_CRYPTO_APP) {
+			if (conn->is_serv) {
+				ret = gnutls_session_ticket_send(session, 1, 0);
+				if (ret) {
+					tlshd_log_gnutls_error(ret);
+					return ret;
+				}
+			}
+			if (!conn->recv_ticket)
+				conn->completed = 1;
+		}
+	}
+	tlshd_log_debug("  Secret func: %u %u %u", secret.level, !!tx_secret, !!rx_secret);
+	return 0;
+}
+
+static int quic_alert_read_func(gnutls_session_t session,
+				gnutls_record_encryption_level_t gtls_level,
+				gnutls_alert_level_t alert_level,
+				gnutls_alert_description_t alert_desc)
+{
+	tlshd_log_notice("%s: %u %u %u %u", __func__,
+			 !!session, gtls_level, alert_level, alert_desc);
+	return 0;
+}
+
+static int quic_tp_recv_func(gnutls_session_t session, const uint8_t *buf, size_t len)
+{
+	struct tlshd_quic_conn *conn = gnutls_session_get_ptr(session);
+	int sockfd = conn->parms->sockfd;
+
+	if (setsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_TRANSPORT_PARAM_EXT, buf, len)) {
+		tlshd_log_error("socket setsockopt transport_param_ext error %d", errno);
+		return -1;
+	}
+	return 0;
+}
+
+static int quic_tp_send_func(gnutls_session_t session, gnutls_buffer_t extdata)
+{
+	struct tlshd_quic_conn *conn = gnutls_session_get_ptr(session);
+	int ret, sockfd = conn->parms->sockfd;
+	uint8_t buf[256];
+	unsigned int len;
+
+	len = sizeof(buf);
+	if (getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_TRANSPORT_PARAM_EXT, buf, &len)) {
+		tlshd_log_error("socket getsockopt transport_param_ext error %d", errno);
+		return -1;
+	}
+
+	ret = gnutls_buffer_append_data(extdata, buf, len);
+	if (ret) {
+		tlshd_log_gnutls_error(ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+#define QUIC_MAX_FRAG_LEN	1200
+
+static int quic_read_func(gnutls_session_t session, gnutls_record_encryption_level_t level,
+			  gnutls_handshake_description_t htype, const void *data, size_t datalen)
+{
+	struct tlshd_quic_conn *conn = gnutls_session_get_ptr(session);
+	struct tlshd_quic_msg *msg;
+	uint32_t len = datalen;
+
+	if (htype == GNUTLS_HANDSHAKE_KEY_UPDATE)
+		return 0;
+
+	while (len > 0) {
+		msg = malloc(sizeof(*msg));
+		if (!msg) {
+			tlshd_log_error("msg malloc error %d", ENOMEM);
+			return -1;
+		}
+		memset(msg, 0, sizeof(*msg));
+		msg->len = len;
+		if (len > QUIC_MAX_FRAG_LEN)
+			msg->len = QUIC_MAX_FRAG_LEN;
+		memcpy(msg->data, data, msg->len);
+
+		msg->level = quic_get_crypto_level(level);
+		if (!conn->send_list)
+			conn->send_list = msg;
+		else
+			conn->send_last->next = msg;
+		conn->send_last = msg;
+
+		len -= msg->len;
+		data += msg->len;
+	}
+
+	tlshd_log_debug("  Read func: %u %u %u", level, htype, datalen);
+	return 0;
+}
+
+static char quic_priority[] =
+	"%DISABLE_TLS13_COMPAT_MODE:NORMAL:-VERS-ALL:+VERS-TLS1.3:+PSK:-CIPHER-ALL:+";
+
+static int quic_session_set_priority(gnutls_session_t session, uint32_t cipher)
+{
+	char p[136] = {};
+
+	memcpy(p, quic_priority, strlen(quic_priority));
+	switch (cipher) {
+	case TLS_CIPHER_AES_GCM_128:
+		strcat(p, "AES-128-GCM");
+		break;
+	case TLS_CIPHER_AES_GCM_256:
+		strcat(p, "AES-256-GCM");
+		break;
+	case TLS_CIPHER_AES_CCM_128:
+		strcat(p, "AES-128-CCM");
+		break;
+	case TLS_CIPHER_CHACHA20_POLY1305:
+		strcat(p, "CHACHA20-POLY1305");
+		break;
+	default:
+		strcat(p, "AES-128-GCM:+AES-256-GCM:+AES-128-CCM:+CHACHA20-POLY1305");
+	}
+
+	return gnutls_priority_set_direct(session, p, NULL);
+}
+
+static int quic_session_set_alpns(gnutls_session_t session, char *alpn_data)
+{
+	gnutls_datum_t alpns[TLSHD_QUIC_MAX_ALPNS_LEN / 2];
+	char *alpn = strtok(alpn_data, ",");
+	int count = 0;
+
+	while (alpn) {
+		while (*alpn == ' ')
+			alpn++;
+		alpns[count].data = (unsigned char *)alpn;
+		alpns[count].size = strlen(alpn);
+		count++;
+		alpn = strtok(NULL, ",");
+	}
+
+	return gnutls_alpn_set_protocols(session, alpns, count, GNUTLS_ALPN_MANDATORY);
+}
+
+static gnutls_record_encryption_level_t quic_get_encryption_level(uint8_t level)
+{
+	switch (level) {
+	case QUIC_CRYPTO_INITIAL:
+		return GNUTLS_ENCRYPTION_LEVEL_INITIAL;
+	case QUIC_CRYPTO_HANDSHAKE:
+		return GNUTLS_ENCRYPTION_LEVEL_HANDSHAKE;
+	case QUIC_CRYPTO_APP:
+		return GNUTLS_ENCRYPTION_LEVEL_APPLICATION;
+	case QUIC_CRYPTO_EARLY:
+		return GNUTLS_ENCRYPTION_LEVEL_EARLY;
+	default:
+		tlshd_log_notice("%s: %d", __func__, level);
+		return GNUTLS_ENCRYPTION_LEVEL_APPLICATION + 1;
+	}
+}
+
+static int quic_conn_get_transport_param(struct tlshd_quic_conn *conn)
+{
+	struct quic_transport_param param = {};
+	int sockfd = conn->parms->sockfd;
+	unsigned int len;
+
+	len = sizeof(conn->alpns);
+	if (getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_ALPN, conn->alpns, &len)) {
+		tlshd_log_error("socket getsockopt alpn error %d", errno);
+		return -1;
+	}
+	len = sizeof(conn->ticket);
+	if (getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_SESSION_TICKET, conn->ticket, &len)) {
+		tlshd_log_error("socket getsockopt session ticket error %d", errno);
+		return -1;
+	}
+	conn->ticket_len = len;
+	len = sizeof(param);
+	if (getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_TRANSPORT_PARAM, &param, &len)) {
+		tlshd_log_error("socket getsockopt transport param error %d", errno);
+		return -1;
+	}
+	conn->recv_ticket = param.receive_session_ticket;
+	conn->cert_req = param.certificate_request;
+	conn->cipher = param.payload_cipher_type;
+	return 0;
+}
+
+static int quic_handshake_sendmsg(int sockfd, struct tlshd_quic_msg *msg)
+{
+	char outcmsg[CMSG_SPACE(sizeof(struct quic_handshake_info))];
+	struct quic_handshake_info *info;
+	struct msghdr outmsg;
+	struct cmsghdr *cmsg;
+	struct iovec iov;
+	int flags = 0;
+
+	outmsg.msg_name = NULL;
+	outmsg.msg_namelen = 0;
+	outmsg.msg_iov = &iov;
+	iov.iov_base = (void *)msg->data;
+	iov.iov_len = msg->len;
+	outmsg.msg_iovlen = 1;
+
+	outmsg.msg_control = outcmsg;
+	outmsg.msg_controllen = sizeof(outcmsg);
+	outmsg.msg_flags = 0;
+	if (msg->next)
+		flags = MSG_MORE;
+
+	cmsg = CMSG_FIRSTHDR(&outmsg);
+	cmsg->cmsg_level = IPPROTO_QUIC;
+	cmsg->cmsg_type = QUIC_HANDSHAKE_INFO;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(*info));
+
+	info = (struct quic_handshake_info *)CMSG_DATA(cmsg);
+	info->crypto_level = msg->level;
+
+	return sendmsg(sockfd, &outmsg, flags);
+}
+
+static int quic_handshake_recvmsg(int sockfd, struct tlshd_quic_msg *msg)
+{
+	char incmsg[CMSG_SPACE(sizeof(struct quic_handshake_info))];
+	struct quic_handshake_info info;
+	struct cmsghdr *cmsg = NULL;
+	struct msghdr inmsg;
+	struct iovec iov;
+	int ret;
+
+	msg->len = 0;
+	memset(&inmsg, 0, sizeof(inmsg));
+
+	iov.iov_base = msg->data;
+	iov.iov_len = sizeof(msg->data);
+
+	inmsg.msg_name = NULL;
+	inmsg.msg_namelen = 0;
+	inmsg.msg_iov = &iov;
+	inmsg.msg_iovlen = 1;
+	inmsg.msg_control = incmsg;
+	inmsg.msg_controllen = sizeof(incmsg);
+
+	ret = recvmsg(sockfd, &inmsg, 0);
+	if (ret < 0)
+		return ret;
+	msg->len = ret;
+
+	for (cmsg = CMSG_FIRSTHDR(&inmsg); cmsg != NULL; cmsg = CMSG_NXTHDR(&inmsg, cmsg))
+		if (IPPROTO_QUIC == cmsg->cmsg_level && QUIC_HANDSHAKE_INFO == cmsg->cmsg_type)
+			break;
+	if (cmsg) {
+		memcpy(&info, CMSG_DATA(cmsg), sizeof(info));
+		msg->level = info.crypto_level;
+	}
+
+	return ret;
+}
+
+static int quic_handshake_completed(struct tlshd_quic_conn *conn)
+{
+	return conn->completed || conn->errcode;
+}
+
+static int quic_handshake_crypto_data(struct tlshd_quic_conn *conn, uint8_t level,
+				      const uint8_t *data, size_t datalen)
+{
+	gnutls_session_t session = conn->session;
+	int ret;
+
+	level = quic_get_encryption_level(level);
+	if (datalen > 0) {
+		ret = gnutls_handshake_write(session, level, data, datalen);
+		if (ret != 0) {
+			if (!gnutls_error_is_fatal(ret))
+				return 0;
+			goto err;
+		}
+	}
+
+	ret = gnutls_handshake(session);
+	if (ret < 0) {
+		if (!gnutls_error_is_fatal(ret))
+			return 0;
+		goto err;
+	}
+	return 0;
+err:
+	gnutls_alert_send_appropriate(session, ret);
+	tlshd_log_gnutls_error(ret);
+	return ret;
+}
+
+/**
+ * tlshd_quic_conn_create - Create a context for QUIC handshake
+ * @conn_p: pointer to accept the QUIC handshake context created
+ * @parms: handshake parameters
+ *
+ * Returns: %0 on success, or a negative error code
+ */
+int tlshd_quic_conn_create(struct tlshd_quic_conn **conn_p, struct tlshd_handshake_parms *parms)
+{
+	struct tlshd_quic_conn *conn;
+	int ret;
+
+	conn = malloc(sizeof(*conn));
+	if (!conn) {
+		tlshd_log_error("conn malloc error %d", ENOMEM);
+		return -ENOMEM;
+	}
+
+	memset(conn, 0, sizeof(*conn));
+	conn->parms = parms;
+
+	if (quic_conn_get_transport_param(conn)) {
+		ret = -errno;
+		goto err;
+	}
+
+	if (quic_conn_setup_timer(conn)) {
+		ret = -errno;
+		goto err;
+	}
+
+	*conn_p = conn;
+	return 0;
+err:
+	tlshd_quic_conn_destroy(conn);
+	return ret;
+}
+
+/**
+ * tlshd_quic_conn_destroy - Destroy a context for QUIC handshake
+ * @conn: QUIC handshake context to destroy
+ *
+ */
+void tlshd_quic_conn_destroy(struct tlshd_quic_conn *conn)
+{
+	struct tlshd_quic_msg *msg = conn->send_list;
+
+	while (msg) {
+		conn->send_list = msg->next;
+		free(msg);
+		msg = conn->send_list;
+	}
+
+	quic_conn_delete_timer(conn);
+	gnutls_deinit(conn->session);
+	free(conn);
+}
+
+#define QUIC_TLSEXT_TP_PARAM	0x39u
+
+/**
+ * tlshd_quic_session_configure - Configure a handshake session
+ * @session: TLS session to configure
+ * @alpns: multiple ALPNs split by ','
+ * @cipher: cipher perferred
+ *
+ * Returns: %GNUTLS_E_SUCCESS on success, or a negative error code
+ */
+int tlshd_quic_session_configure(gnutls_session_t session, char *alpns, uint32_t cipher)
+{
+	int ret;
+
+	ret = quic_session_set_priority(session, cipher);
+	if (ret)
+		return ret;
+
+	if (alpns[0]) {
+		ret = quic_session_set_alpns(session, alpns);
+		if (ret)
+			return ret;
+	}
+
+	gnutls_handshake_set_secret_function(session, quic_secret_func);
+	gnutls_handshake_set_read_function(session, quic_read_func);
+	gnutls_alert_set_read_function(session, quic_alert_read_func);
+
+	return gnutls_session_ext_register(
+		session, "QUIC Transport Parameters", QUIC_TLSEXT_TP_PARAM,
+		GNUTLS_EXT_TLS, quic_tp_recv_func, quic_tp_send_func, NULL, NULL, NULL,
+		GNUTLS_EXT_FLAG_TLS | GNUTLS_EXT_FLAG_CLIENT_HELLO | GNUTLS_EXT_FLAG_EE);
+}
+
+/**
+ * tlshd_quic_start_handshake - Drive the handshake interaction
+ * @conn: QUIC handshake context
+ *
+ */
+void tlshd_quic_start_handshake(struct tlshd_quic_conn *conn)
+{
+	int ret, sockfd = conn->parms->sockfd;
+	struct timeval tv = {1, 0};
+	struct tlshd_quic_msg *msg;
+	fd_set readfds;
+
+	FD_ZERO(&readfds);
+	FD_SET(sockfd, &readfds);
+
+	if (!conn->is_serv) {
+		ret = quic_handshake_crypto_data(conn, QUIC_CRYPTO_INITIAL, NULL, 0);
+		if (ret) {
+			conn->errcode = -ret;
+			return;
+		}
+
+		msg = conn->send_list;
+		while (msg) {
+			tlshd_log_debug("< Handshake SEND: %d %d", msg->len, msg->level);
+			ret = quic_handshake_sendmsg(sockfd, msg);
+			if (ret < 0) {
+				tlshd_log_error("socket sendmsg error %d", errno);
+				conn->errcode = errno;
+				return;
+			}
+			conn->send_list = msg->next;
+			free(msg);
+			msg = conn->send_list;
+		}
+	}
+
+	while (!quic_handshake_completed(conn)) {
+		ret = select(sockfd + 1, &readfds, NULL,  NULL, &tv);
+		if (ret < 0) {
+			conn->errcode = errno;
+			return tlshd_log_error("socket select error %d", errno);
+		}
+		msg = &conn->recv_msg;
+		while (!quic_handshake_completed(conn)) {
+			ret = quic_handshake_recvmsg(sockfd, msg);
+			if (ret <= 0) {
+				if (errno == EAGAIN || errno == EWOULDBLOCK)
+					break;
+				conn->errcode = errno;
+				return tlshd_log_error("socket recvmsg error %d", errno);
+			}
+			tlshd_log_debug("> Handshake RECV: %u %u", msg->len, msg->level);
+			ret = quic_handshake_crypto_data(conn, msg->level, msg->data, msg->len);
+			if (ret) {
+				conn->errcode = -ret;
+				return;
+			}
+		}
+
+		msg = conn->send_list;
+		while (msg) {
+			tlshd_log_debug("< Handshake SEND: %u %u", msg->len, msg->level);
+			ret = quic_handshake_sendmsg(sockfd, msg);
+			if (ret < 0) {
+				conn->errcode = errno;
+				return tlshd_log_error("socket sendmsg error %d", errno);
+			}
+			conn->send_list = msg->next;
+			free(msg);
+			msg = conn->send_list;
+		}
+	}
+}
+#endif

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -2,6 +2,7 @@
  * Perform a TLSv1.3 server-side handshake.
  *
  * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Red Hat, Inc.
  *
  * ktls-utils is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -128,6 +129,7 @@ tlshd_x509_retrieve_key_cb(gnutls_session_t session,
 /**
  * tlshd_server_x509_verify_function - Verify remote's x.509 certificate
  * @session: session in the midst of a handshake
+ * @parms: handshake parameters
  *
  * A return value of %GNUTLS_E_SUCCESS indicates that the TLS session
  * has been allowed to continue. tlshd either sets the peerid array if
@@ -139,16 +141,14 @@ tlshd_x509_retrieve_key_cb(gnutls_session_t session,
  * A return value of %GNUTLS_E_CERTIFICATE_ERROR means that certificate
  * verification failed. The server sends an ALERT to the client.
  */
-static int tlshd_server_x509_verify_function(gnutls_session_t session)
+static int tlshd_server_x509_verify_function(gnutls_session_t session,
+					     struct tlshd_handshake_parms *parms)
 {
-	struct tlshd_handshake_parms *parms;
 	const gnutls_datum_t *peercerts;
 	gnutls_certificate_type_t type;
 	unsigned int i, status;
 	gnutls_datum_t out;
 	int ret;
-
-	parms = gnutls_session_get_ptr(session);
 
 	ret = gnutls_certificate_verify_peers3(session, NULL, &status);
 	switch (ret) {
@@ -207,6 +207,13 @@ certificate_error:
 	return GNUTLS_E_CERTIFICATE_ERROR;
 }
 
+static int tlshd_tls13_server_x509_verify_function(gnutls_session_t session)
+{
+	struct tlshd_handshake_parms *parms = gnutls_session_get_ptr(session);
+
+	return tlshd_server_x509_verify_function(session, parms);
+}
+
 static void tlshd_tls13_server_x509_handshake(struct tlshd_handshake_parms *parms)
 {
 	gnutls_certificate_credentials_t xcred;
@@ -255,7 +262,7 @@ static void tlshd_tls13_server_x509_handshake(struct tlshd_handshake_parms *parm
 		goto out_free_creds;
 	}
 	gnutls_certificate_set_verify_function(xcred,
-					       tlshd_server_x509_verify_function);
+					       tlshd_tls13_server_x509_verify_function);
 	gnutls_certificate_server_set_request(session, GNUTLS_CERT_REQUEST);
 
 	ret = tlshd_gnutls_priority_set(session, parms, 0);
@@ -370,3 +377,234 @@ void tlshd_tls13_serverhello_handshake(struct tlshd_handshake_parms *parms)
 				parms->auth_mode);
 	}
 }
+
+#ifdef HAVE_GNUTLS_QUIC
+static int tlshd_quic_server_alpn_verify(gnutls_session_t session, unsigned int htype,
+					 unsigned int when, unsigned int incoming,
+					 const gnutls_datum_t *msg)
+{
+	struct tlshd_quic_conn *conn = gnutls_session_get_ptr(session);
+	gnutls_datum_t alpn = {};
+	int ret;
+
+	if (!conn->alpns[0])
+		return 0;
+
+	ret = gnutls_alpn_get_selected_protocol(session, &alpn);
+	if (ret) {
+		tlshd_log_gnutls_error(ret);
+		return ret;
+	}
+	if (setsockopt(conn->parms->sockfd, SOL_QUIC, QUIC_SOCKOPT_ALPN, alpn.data, alpn.size)) {
+		tlshd_log_error("socket setsockopt alpn error %d %u", errno, alpn.size);
+		return -1;
+	}
+	tlshd_log_debug("  ALPN verify: %u %u %u %u", htype, when, incoming, msg->size);
+	return 0;
+}
+
+static int tlshd_quic_server_anti_replay_db_add_func(void *dbf, time_t exp_time,
+						     const gnutls_datum_t *key,
+						     const gnutls_datum_t *data)
+{
+	tlshd_log_debug("  Anti replay: %u %u %u %u", !!dbf, exp_time, key->size, data->size);
+	return 0;
+}
+
+static gnutls_anti_replay_t tlshd_quic_server_anti_replay;
+
+static int tlshd_quic_server_x509_verify_function(gnutls_session_t session)
+{
+	struct tlshd_quic_conn *conn = gnutls_session_get_ptr(session);
+
+	return tlshd_server_x509_verify_function(session, conn->parms);
+}
+
+static int tlshd_quic_server_psk_cb(gnutls_session_t session, const char *username,
+				    gnutls_datum_t *key)
+{
+	struct tlshd_quic_conn *conn = gnutls_session_get_ptr(session);
+	struct tlshd_handshake_parms *parms = conn->parms;
+	key_serial_t psk;
+	long ret;
+
+	ret = keyctl_search(KEY_SPEC_SESSION_KEYRING, "psk", username, 0);
+	if (ret >= 0)
+		goto found;
+
+	ret = keyctl_search(KEY_SPEC_SESSION_KEYRING, "user", username, 0);
+	if (ret < 0) {
+		tlshd_log_error("key search error %d %s", errno, username);
+		return -1;
+	}
+
+found:
+	psk = (key_serial_t)ret;
+	if (!tlshd_keyring_get_psk_key(psk, key)) {
+		tlshd_log_error("key load error %d", errno);
+		return -1;
+	}
+
+	/* PSK uses the same identity for both client and server */
+	parms->remote_peerid[0] = psk;
+	parms->num_remote_peerids = 1;
+	return 0;
+}
+
+static int tlshd_quic_server_set_x509_session(struct tlshd_quic_conn *conn)
+{
+	struct tlshd_handshake_parms *parms = conn->parms;
+	gnutls_certificate_credentials_t cred;
+	gnutls_datum_t ticket_key;
+	gnutls_session_t session;
+	int ret = -EINVAL;
+	char *cafile;
+
+	if (!tlshd_x509_server_get_certs(parms) || !tlshd_x509_server_get_privkey(parms)) {
+		tlshd_log_error("cert/privkey get error %d", -ret);
+		return ret;
+	}
+
+	ret = gnutls_certificate_allocate_credentials(&cred);
+	if (ret)
+		goto err;
+	if (tlshd_config_get_server_truststore(&cafile)) {
+		ret = gnutls_certificate_set_x509_trust_file(cred, cafile,
+							     GNUTLS_X509_FMT_PEM);
+		free(cafile);
+	} else
+		ret = gnutls_certificate_set_x509_system_trust(cred);
+	if (ret < 0)
+		goto err_cred;
+	tlshd_log_debug("System trust: Loaded %d certificate(s).", ret);
+
+	gnutls_certificate_set_retrieve_function2(cred, tlshd_x509_retrieve_key_cb);
+
+	gnutls_certificate_set_verify_function(cred, tlshd_quic_server_x509_verify_function);
+
+	ret = gnutls_init(&session, GNUTLS_SERVER | GNUTLS_NO_AUTO_SEND_TICKET |
+				    GNUTLS_ENABLE_EARLY_DATA | GNUTLS_NO_END_OF_EARLY_DATA);
+	if (ret)
+		goto err_cred;
+
+	if (!tlshd_quic_server_anti_replay) {
+		ret = gnutls_anti_replay_init(&tlshd_quic_server_anti_replay);
+		if (ret)
+			goto err_session;
+		gnutls_anti_replay_set_add_function(tlshd_quic_server_anti_replay,
+						    tlshd_quic_server_anti_replay_db_add_func);
+		gnutls_anti_replay_set_ptr(tlshd_quic_server_anti_replay, NULL);
+	}
+	gnutls_anti_replay_enable(session, tlshd_quic_server_anti_replay);
+	ret = gnutls_record_set_max_early_data_size(session, 0xffffffffu);
+	if (ret)
+		goto err_session;
+
+	gnutls_session_set_ptr(session, conn);
+	ret = tlshd_quic_session_configure(session, conn->alpns, conn->cipher);
+	if (ret)
+		goto err_session;
+	ticket_key.data = conn->ticket;
+	ticket_key.size = conn->ticket_len;
+	ret = gnutls_session_ticket_enable_server(session, &ticket_key);
+	if (ret)
+		goto err_session;
+	gnutls_handshake_set_hook_function(session, GNUTLS_HANDSHAKE_CLIENT_HELLO,
+					   GNUTLS_HOOK_POST, tlshd_quic_server_alpn_verify);
+	ret = gnutls_credentials_set(session, GNUTLS_CRD_CERTIFICATE, cred);
+	if (ret)
+		goto err_session;
+	gnutls_certificate_server_set_request(session, conn->cert_req);
+
+	conn->is_serv = 1;
+	conn->session = session;
+	return 0;
+err_session:
+	gnutls_deinit(session);
+err_cred:
+	gnutls_certificate_free_credentials(cred);
+err:
+	tlshd_log_gnutls_error(ret);
+	return ret;
+}
+
+static int tlshd_quic_server_set_psk_session(struct tlshd_quic_conn *conn)
+{
+	gnutls_psk_server_credentials_t cred;
+	gnutls_session_t session;
+	int ret;
+
+	ret = gnutls_psk_allocate_server_credentials(&cred);
+	if (ret)
+		goto err;
+	gnutls_psk_set_server_credentials_function(cred, tlshd_quic_server_psk_cb);
+
+	ret = gnutls_init(&session, GNUTLS_SERVER | GNUTLS_NO_AUTO_SEND_TICKET);
+	if (ret)
+		goto err_cred;
+	gnutls_session_set_ptr(session, conn);
+	ret = tlshd_quic_session_configure(session, conn->alpns, conn->cipher);
+	if (ret)
+		goto err_session;
+	gnutls_handshake_set_hook_function(session, GNUTLS_HANDSHAKE_CLIENT_HELLO,
+					   GNUTLS_HOOK_POST, tlshd_quic_server_alpn_verify);
+	ret = gnutls_credentials_set(session, GNUTLS_CRD_PSK, cred);
+	if (ret)
+		goto err_session;
+
+	conn->is_serv = 1;
+	conn->session = session;
+	return 0;
+err_session:
+	gnutls_deinit(session);
+err_cred:
+	gnutls_psk_free_server_credentials(cred);
+err:
+	tlshd_log_gnutls_error(ret);
+	return ret;
+}
+
+/**
+ * tlshd_quic_serverhello_handshake - send a QUIC Server Initial
+ * @parms: handshake parameters
+ *
+ */
+void tlshd_quic_serverhello_handshake(struct tlshd_handshake_parms *parms)
+{
+	struct tlshd_quic_conn *conn;
+	int ret;
+
+	ret = tlshd_quic_conn_create(&conn, parms);
+	if (ret) {
+		parms->session_status = ret;
+		return gnutls_global_deinit();
+	}
+
+	switch (parms->auth_mode) {
+	case HANDSHAKE_AUTH_X509:
+		ret = tlshd_quic_server_set_x509_session(conn);
+		break;
+	case HANDSHAKE_AUTH_PSK:
+		ret = tlshd_quic_server_set_psk_session(conn);
+		break;
+	default:
+		ret = -EINVAL;
+		tlshd_log_debug("Unrecognized auth mode (%d)", parms->auth_mode);
+	}
+	if (ret) {
+		conn->errcode = -ret;
+		goto out;
+	}
+
+	tlshd_quic_start_handshake(conn);
+out:
+	parms->session_status = conn->errcode;
+	tlshd_quic_conn_destroy(conn);
+}
+#else
+void tlshd_quic_serverhello_handshake(struct tlshd_handshake_parms *parms)
+{
+	tlshd_log_debug("QUIC handshake is not enabled (%d)", parms->auth_mode);
+	parms->session_status = EOPNOTSUPP;
+}
+#endif

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -207,7 +207,7 @@ certificate_error:
 	return GNUTLS_E_CERTIFICATE_ERROR;
 }
 
-static void tlshd_server_x509_handshake(struct tlshd_handshake_parms *parms)
+static void tlshd_tls13_server_x509_handshake(struct tlshd_handshake_parms *parms)
 {
 	gnutls_certificate_credentials_t xcred;
 	gnutls_session_t session;
@@ -312,7 +312,7 @@ static int tlshd_server_psk_cb(gnutls_session_t session,
 	return 0;
 }
 
-static void tlshd_server_psk_handshake(struct tlshd_handshake_parms *parms)
+static void tlshd_tls13_server_psk_handshake(struct tlshd_handshake_parms *parms)
 {
 	gnutls_psk_server_credentials_t psk_cred;
 	gnutls_session_t session;
@@ -352,41 +352,21 @@ out_free_creds:
 }
 
 /**
- * tlshd_serverhello_handshake - send a TLSv1.3 ServerHello
+ * tlshd_tls13_serverhello_handshake - send a TLSv1.3 ServerHello
  * @parms: handshake parameters
  *
  */
-void tlshd_serverhello_handshake(struct tlshd_handshake_parms *parms)
+void tlshd_tls13_serverhello_handshake(struct tlshd_handshake_parms *parms)
 {
-	int ret;
-
-	ret = gnutls_global_init();
-	if (ret != GNUTLS_E_SUCCESS) {
-		tlshd_log_gnutls_error(ret);
-		return;
-	}
-
-	if (tlshd_tls_debug)
-		gnutls_global_set_log_level(tlshd_tls_debug);
-	gnutls_global_set_log_function(tlshd_gnutls_log_func);
-	gnutls_global_set_audit_log_function(tlshd_gnutls_audit_func);
-
-#ifdef HAVE_GNUTLS_GET_SYSTEM_CONFIG_FILE
-	tlshd_log_debug("System config file: %s",
-			gnutls_get_system_config_file());
-#endif
-
 	switch (parms->auth_mode) {
 	case HANDSHAKE_AUTH_X509:
-		tlshd_server_x509_handshake(parms);
+		tlshd_tls13_server_x509_handshake(parms);
 		break;
 	case HANDSHAKE_AUTH_PSK:
-		tlshd_server_psk_handshake(parms);
+		tlshd_tls13_server_psk_handshake(parms);
 		break;
 	default:
 		tlshd_log_debug("Unrecognized auth mode (%d)",
 				parms->auth_mode);
 	}
-
-	gnutls_global_deinit();
 }

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -32,6 +32,7 @@ struct tlshd_handshake_parms {
 	struct sockaddr *peeraddr;
 	socklen_t	peeraddr_len;
 	int		sockfd;
+	int		ip_proto;
 	uint32_t	handshake_type;
 	unsigned int	timeout_ms;
 	uint32_t	auth_mode;

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -48,7 +48,7 @@ struct tlshd_handshake_parms {
 };
 
 /* client.c */
-extern void tlshd_clienthello_handshake(struct tlshd_handshake_parms *parms);
+extern void tlshd_tls13_clienthello_handshake(struct tlshd_handshake_parms *parms);
 
 /* config.c */
 bool tlshd_config_init(const gchar *pathname);
@@ -118,7 +118,7 @@ extern int tlshd_genl_get_handshake_parms(struct tlshd_handshake_parms *parms);
 extern void tlshd_genl_done(struct tlshd_handshake_parms *parms);
 
 /* server.c */
-extern void tlshd_serverhello_handshake(struct tlshd_handshake_parms *parms);
+extern void tlshd_tls13_serverhello_handshake(struct tlshd_handshake_parms *parms);
 
 #define TLS_DEFAULT_PRIORITIES	(NULL)
 #define TLS_NO_PEERID		(0)


### PR DESCRIPTION
This patch adds QUIC handshake support to tlshd, utilizing GnuTLS for TLS message handling and integrating with existing code for PSK and certificate verification. The feature is conditionally compiled based on kernel and GnuTLS capabilities. See each commit for more details.

With the feedback from Chuck Lever, v1->v2:
  - Delete the basic test description from the cover letter.
  - Refactor tlshd_service_socket() by Chuck in patch 1/3.
  - Include socket ip_proto in tlshd_handshake_parms in patch 2/3.
  - Replace HAVE_QUIC with HAVE_GNUTLS_QUIC and move the check for QUIC handshakes into the switch statement in tlshd_service_socket() in patch 3/3.

With more feedback from Chuck, v2->v3:
  - use switch statement for different ip_proto and set parms.session_status to EOPNOTSUPP in tlshd_service_socket() if it's not supported in patch 3/3.
  - move server related functions from quic.c to server.c, and client related to client.c, and structs to tlshd.h in patch 3/3.
  - keep the functions shared by both server and client to quic.c, and rename some functions and export them in patch 3/3.
  - do keyctl_search for both "psk" and "user" types of keys in tlshd_quic_server_psk_cb() in patch 3/3.
  - reuse tlshd_client_x509_verify_function() and tlshd_server_x509_verify_function() for quic handshake in patch 3/3.