### PR TITLE
Release ktls-utils 0.11

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 Change Log - In newest-release-first order
 
+ktls-utils 0.11 - 2024-06-05
+ * Add support for chained certs
+ * Move to-do items to the GitHub issue tracker
+ * Fix minor bugs
+
 ktls-utils 0.10 - 2023-09-21
  * Fix Server Name Indicator support (IP addresses)
  * Add tlshd.conf option to provide specific trust chain

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,4 @@
-ktls-utils 0.10 - 2023-09-21
- * Fix Server Name Indicator support (IP addresses)
- * Add tlshd.conf option to provide specific trust chain
- * Reorganize tlshd.conf
- * Fix numerous bugs reported by packagers
+ktls-utils 0.11 - 2024-06-05
+ * Add support for chained certs
+ * Move to-do items to the GitHub issue tracker
+ * Fix minor bugs

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 0.11-dev
+# Release Notes for ktls-utils 0.11
 
 Note well: This is experimental prototype software. It's purpose is
 purely as a demonstration and proof-of-concept. USE AT YOUR OWN RISK.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 0.11-dev
+# Release Notes for ktls-utils 0.11
 
 Note well: This is experimental prototype software. It's purpose is
 purely as a demonstration and proof-of-concept. USE AT YOUR OWN RISK.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ dnl 02110-1301, USA.
 dnl
 
 AC_PREREQ([2.69])
-AC_INIT([ktls-utils],[0.11-dev],[kernel-tls-handshake@lists.linux.dev])
+AC_INIT([ktls-utils],[0.11],[kernel-tls-handshake@lists.linux.dev])
 AM_INIT_AUTOMAKE
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([config.h.in])


### PR DESCRIPTION
ktls-utils 0.11 - 2024-06-05
 * Add support for chained certs
 * Move to-do items to the GitHub issue tracker
 * Fix minor bugs