### PR TITLE
tlshd: improve error logging for tlshd_server_psk_cb()

### DIFF
--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -288,15 +288,17 @@ static int tlshd_server_psk_cb(gnutls_session_t session,
 
 	parms = gnutls_session_get_ptr(session);
 
-	ret = keyctl_search(KEY_SPEC_SESSION_KEYRING, "psk", username, 0);
+	ret = keyctl_search(KEY_SPEC_SESSION_KEYRING,
+			    TLS_DEFAULT_PSK_TYPE, username, 0);
 	if (ret < 0) {
-		tlshd_log_error("failed to search key");
+		tlshd_log_error("failed to search '%s' key '%s'",
+				TLS_DEFAULT_PSK_TYPE, username);
 		return -1;
 	}
 
 	psk = (key_serial_t)ret;
 	if (!tlshd_keyring_get_psk_key(psk, key)) {
-		tlshd_log_error("failed to load key");
+		tlshd_log_error("failed to load key %lu", (unsigned long)psk);
 		return -1;
 	}
 

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -122,6 +122,7 @@ extern void tlshd_genl_done(struct tlshd_handshake_parms *parms);
 extern void tlshd_serverhello_handshake(struct tlshd_handshake_parms *parms);
 
 #define TLS_DEFAULT_PRIORITIES	(NULL)
+#define TLS_DEFAULT_PSK_TYPE	"psk"
 #define TLS_NO_PEERID		(0)
 #define TLS_NO_CERT		(0)
 #define TLS_NO_PRIVKEY		(0)


### PR DESCRIPTION
Improve the logging message when looking up the psk to include the TLS identity for better debugging.