### PR TITLE
Test PR number two

### DIFF
--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -207,7 +207,7 @@ certificate_error:
 	return GNUTLS_E_CERTIFICATE_ERROR;
 }
 
-static void tlshd_server_x509_handshake(struct tlshd_handshake_parms *parms)
+static void tlshd_tls13_server_x509_handshake(struct tlshd_handshake_parms *parms)
 {
 	gnutls_certificate_credentials_t xcred;
 	gnutls_session_t session;
@@ -312,7 +312,7 @@ static int tlshd_server_psk_cb(gnutls_session_t session,
 	return 0;
 }
 
-static void tlshd_server_psk_handshake(struct tlshd_handshake_parms *parms)
+static void tlshd_tls13_server_psk_handshake(struct tlshd_handshake_parms *parms)
 {
 	gnutls_psk_server_credentials_t psk_cred;
 	gnutls_session_t session;
@@ -352,41 +352,21 @@ out_free_creds:
 }
 
 /**
- * tlshd_serverhello_handshake - send a TLSv1.3 ServerHello
+ * tlshd_tls13_serverhello_handshake - send a TLSv1.3 ServerHello
  * @parms: handshake parameters
  *
  */
-void tlshd_serverhello_handshake(struct tlshd_handshake_parms *parms)
+void tlshd_tls13_serverhello_handshake(struct tlshd_handshake_parms *parms)
 {
-	int ret;
-
-	ret = gnutls_global_init();
-	if (ret != GNUTLS_E_SUCCESS) {
-		tlshd_log_gnutls_error(ret);
-		return;
-	}
-
-	if (tlshd_tls_debug)
-		gnutls_global_set_log_level(tlshd_tls_debug);
-	gnutls_global_set_log_function(tlshd_gnutls_log_func);
-	gnutls_global_set_audit_log_function(tlshd_gnutls_audit_func);
-
-#ifdef HAVE_GNUTLS_GET_SYSTEM_CONFIG_FILE
-	tlshd_log_debug("System config file: %s",
-			gnutls_get_system_config_file());
-#endif
-
 	switch (parms->auth_mode) {
 	case HANDSHAKE_AUTH_X509:
-		tlshd_server_x509_handshake(parms);
+		tlshd_tls13_server_x509_handshake(parms);
 		break;
 	case HANDSHAKE_AUTH_PSK:
-		tlshd_server_psk_handshake(parms);
+		tlshd_tls13_server_psk_handshake(parms);
 		break;
 	default:
 		tlshd_log_debug("Unrecognized auth mode (%d)",
 				parms->auth_mode);
 	}
-
-	gnutls_global_deinit();
 }

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -48,7 +48,7 @@ struct tlshd_handshake_parms {
 };
 
 /* client.c */
-extern void tlshd_clienthello_handshake(struct tlshd_handshake_parms *parms);
+extern void tlshd_tls13_clienthello_handshake(struct tlshd_handshake_parms *parms);
 
 /* config.c */
 bool tlshd_config_init(const gchar *pathname);
@@ -118,7 +118,7 @@ extern int tlshd_genl_get_handshake_parms(struct tlshd_handshake_parms *parms);
 extern void tlshd_genl_done(struct tlshd_handshake_parms *parms);
 
 /* server.c */
-extern void tlshd_serverhello_handshake(struct tlshd_handshake_parms *parms);
+extern void tlshd_tls13_serverhello_handshake(struct tlshd_handshake_parms *parms);
 
 #define TLS_DEFAULT_PRIORITIES	(NULL)
 #define TLS_NO_PEERID		(0)


### PR DESCRIPTION
Pull some common code into tlshd_service_socket(), and rename the client and server handshake functions to make it clear they are TLSv1.3-specific.

This is a pre-requisite to adding QUIC handshake support.