### PR TITLE
Remove package "experimental" status

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,7 +16,7 @@ jobs:
           - linux/arm64
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |

--- a/README
+++ b/README
@@ -1,8 +1,5 @@
 # Release Notes for ktls-utils 0.12-pre
 
-Note well: This is experimental prototype software. It's purpose is
-purely as a demonstration and proof-of-concept. USE AT YOUR OWN RISK.
-
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can
 then be programmed into the kernel's TLS record protocol engine.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Release Notes for ktls-utils 0.12-pre
 
-Note well: This is experimental prototype software. It's purpose is
-purely as a demonstration and proof-of-concept. USE AT YOUR OWN RISK.
-
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can
 then be programmed into the kernel's TLS record protocol engine.

--- a/src/tlshd/tlshd.conf.man
+++ b/src/tlshd/tlshd.conf.man
@@ -112,10 +112,6 @@ a handshake request when no other certificate is available.
 .B x509.private_key
 This option specifies the pathname of a file containing
 a PEM-encoded private key associated with the above certificate.
-.SH NOTES
-This software is a prototype.
-It's purpose is for demonstration and as a proof-of-concept.
-USE THIS SOFTWARE AT YOUR OWN RISK.
 .SH SEE ALSO
 .BR tlshd (8)
 .SH AUTHOR

--- a/src/tlshd/tlshd.man
+++ b/src/tlshd/tlshd.man
@@ -76,10 +76,6 @@ enabling decryption of recorded sessions.
 .B GNUTLS_FORCE_FIPS_MODE
 When set to `1', this variable forces the TLS library into FIPS mode
 if FIPS140-2 support is available.
-.SH NOTES
-This software is a prototype.
-It's purpose is for demonstration and as a proof-of-concept.
-USE THIS SOFTWARE AT YOUR OWN RISK.
 .SH SEE ALSO
 .BR tlshd.conf (5),
 .BR ssl (7)


### PR DESCRIPTION
Indicate that ktls-utils is no longer an experimental protocol, but may be used on production systems as part of an enterprise Linux distribution.

Addresses issue #69