### PR TITLE
Prepare next ktls-utils release to be 1.0.0 (no release date planned yet)

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 0.12-pre
+# Release Notes for ktls-utils 1.0.0-pre
 
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 0.12-pre
+# Release Notes for ktls-utils 1.0.0-pre
 
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ dnl 02110-1301, USA.
 dnl
 
 AC_PREREQ([2.69])
-AC_INIT([ktls-utils],[0.12-pre],[kernel-tls-handshake@lists.linux.dev])
+AC_INIT([ktls-utils],[1.0.0-pre],[kernel-tls-handshake@lists.linux.dev])
 AM_INIT_AUTOMAKE
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([config.h.in])


### PR DESCRIPTION
Since "experimental" and "prototype" has been removed, make the next full release of ktls-utils be the one-dot-zero release.