### PR TITLE
tlshd: Ensure libnl-genl3 is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,9 @@ AC_SUBST([GLIB_LIBS])
 PKG_CHECK_MODULES([LIBNL3], libnl-3.0 >= 3.1)
 AC_SUBST([LIBNL3_CFLAGS])
 AC_SUBST([LIBNL3_LIBS])
+PKG_CHECK_MODULES([LIBNL_GENL3], libnl-genl-3.0 >= 3.1)
+AC_SUBST([LIBNL_GENL3_CFLAGS])
+AC_SUBST([LIBNL_GENL3_LIBS])
 
 AC_CHECK_FILE([/usr/include/linux/quic.h],
               [AC_CHECK_LIB([gnutls], [gnutls_handshake_set_secret_function],

--- a/src/tlshd/Makefile.am
+++ b/src/tlshd/Makefile.am
@@ -24,10 +24,11 @@ EXTRA_DIST		= $(man5_MANS) $(man8_MANS)
 
 sbin_PROGRAMS		= tlshd
 tlshd_CFLAGS		= -Werror -Wall -Wextra $(LIBGNUTLS_CFLAGS) \
-			  $(LIBKEYUTILS_CFLAGS) $(GLIB_CFLAGS) $(LIBNL3_CFLAGS)
+			  $(LIBKEYUTILS_CFLAGS) $(GLIB_CFLAGS) $(LIBNL3_CFLAGS) \
+			  $(LIBNL_GENL3_CFLAGS)
 tlshd_SOURCES		= client.c config.c handshake.c keyring.c ktls.c log.c \
 			  main.c netlink.c netlink.h server.c tlshd.h quic.c
 tlshd_LDADD		= $(LIBGNUTLS_LIBS) $(LIBKEYUTILS_LIBS) $(GLIB_LIBS) \
-			  $(LIBNL3_LIBS) -lnl-genl-3
+			  $(LIBNL3_LIBS) $(LIBNL_GENL3_LIBS)
 
 MAINTAINERCLEANFILES	= Makefile.in cscope.out


### PR DESCRIPTION
tlshd depends on libnl-genl3, thus add a explicit check if the library is available.

Fixes: #77 