### PR TITLE
tlshd: always link .nvme default keyring into the session

### DIFF
--- a/src/tlshd/config.c
+++ b/src/tlshd/config.c
@@ -91,10 +91,17 @@ bool tlshd_config_init(const gchar *pathname)
 					      "keyrings", &length, NULL);
 	if (keyrings) {
 		for (i = 0; i < length; i++) {
+			if (!strcmp(keyrings[i], ".nvme"))
+				continue;
 			tlshd_keyring_link_session(keyrings[i]);
 		}
 		g_strfreev(keyrings);
 	}
+	/*
+	 * Always link the default nvme subsystem keyring into the
+	 * session.
+	 */
+	tlshd_keyring_link_session(".nvme");
 
 	return true;
 }


### PR DESCRIPTION
A common use case for tlshd is to authenticate TLS sessions for the nvme subsystem. Currently, the user has to explicitly list a keyring (even the defautl one) in the configuration file so that tlshd running as daemon (started via systemd) to find any key.

Thus always link the default .nvme keyring into the current session, which makes the daemon work out of the box for default configurations.

@hreinecke 