### PR TITLE
Release ktls-utils 1.0-rc1

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -y install gnutls-dev libkeyutils-dev libnl-3-dev libnl-genl-3-dev
+        sudo apt-get -y install gnutls-dev libkeyutils-dev libnl-3-dev libnl-genl-3-dev libglib2.0-dev
 
     - name: Configure
       run: |

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 Change Log - In newest-release-first order
 
+ktls-utils 1.0 - 2025-02-06
+ * Handshake support for in-kernel QUIC
+ * Package is no longer "experimental"
+ * Fix minor bugs
+
 ktls-utils 0.11 - 2024-06-05
  * Add support for chained certs
  * Move to-do items to the GitHub issue tracker

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-ktls-utils 0.11 - 2024-06-05
- * Add support for chained certs
- * Move to-do items to the GitHub issue tracker
+ktls-utils 1.0 - 2025-02-06
+ * Handshake support for in-kernel QUIC
+ * Package is no longer "experimental"
  * Fix minor bugs

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 1.0.0-pre
+# Release Notes for ktls-utils 1.0.0-rc1
 
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 1.0.0-pre
+# Release Notes for ktls-utils 1.0.0-rc1
 
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ dnl 02110-1301, USA.
 dnl
 
 AC_PREREQ([2.69])
-AC_INIT([ktls-utils],[1.0.0-pre],[kernel-tls-handshake@lists.linux.dev])
+AC_INIT([ktls-utils],[1.0.0-rc1],[kernel-tls-handshake@lists.linux.dev])
 AM_INIT_AUTOMAKE
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([config.h.in])


### PR DESCRIPTION
Prepare for ktls-utils 1.0 by creating a first release candidate.