### PR TITLE
tlshd: Pass ETIMEDOUT from gnutls to kernel

### DIFF
--- a/src/tlshd/handshake.c
+++ b/src/tlshd/handshake.c
@@ -94,10 +94,14 @@ void tlshd_start_tls_handshake(gnutls_session_t session,
 		case GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR:
 			tlshd_log_cert_verification_error(session);
 			break;
-		default:
+		case -ETIMEDOUT:
 			tlshd_log_gnutls_error(ret);
+			parms->session_status = -ret;
+			break;
+		default:
+			tlshd_log_notice("tlshd_start_tls_handshake unhandled error %d, returning EACCES\n", ret);
+			parms->session_status = EACCES;
 		}
-		parms->session_status = EACCES;
 		return;
 	}
 


### PR DESCRIPTION
We've had some QE work that's created a condition (some types of connection instability) where the handshake attempt has timed out.  When this happens, tlshd sends EACESS back to the kernel.  However, the kernel may not be expecting this error in the context of some NFS operations, for example: writeback.  It can handle ETIMEDOUT, and we would like the kernel to perform its normal hard/soft retry routines for this case to re-connect to the server.

Add an error switch that clearly denotes the error paths we'd like to send back to the kernel.  For SUNRPC, there are other insteresting errors that might be included (see call_conenct_status() in net/sunrpc/clnt.c), but are ommitted here because we don't have evidence of them in the wild