### PR TITLE
tlshd: configure.ac: Use AC_CHECK_HEADER instead of AC_CHECK_FILE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ PKG_CHECK_MODULES([LIBNL_GENL3], libnl-genl-3.0 >= 3.1)
 AC_SUBST([LIBNL_GENL3_CFLAGS])
 AC_SUBST([LIBNL_GENL3_LIBS])
 
-AC_CHECK_FILE([/usr/include/linux/quic.h],
+AC_CHECK_HEADER([linux/quic.h],
               [AC_CHECK_LIB([gnutls], [gnutls_handshake_set_secret_function],
                             [AC_DEFINE([HAVE_GNUTLS_QUIC], [1], [Define to 1 if QUIC is found.])])])
 


### PR DESCRIPTION
AC_CHECK_FILE doesn't work when cross-compiling [1], which breaks a lot of use cases (like OpenEmbedded for one). Autoconf supports AC_CHECK_HEADER which can be used instead and is more robust [2] so let's use that instead.

1: https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Files.html
2: https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Generic-Headers.html