### PR TITLE
tlshd/netlink: Spawn tlshd_service_socket() as a thread

### DIFF
--- a/src/tlshd/handshake.c
+++ b/src/tlshd/handshake.c
@@ -116,7 +116,7 @@ void tlshd_start_tls_handshake(gnutls_session_t session,
  * tlshd_service_socket - Service a kernel socket needing a key operation
  *
  */
-void tlshd_service_socket(void)
+void *tlshd_service_socket(void *)
 {
 	struct tlshd_handshake_parms parms;
 	int ret;
@@ -189,7 +189,9 @@ out:
 	if (parms.session_status) {
 		tlshd_log_failure(parms.peername, parms.peeraddr,
 				  parms.peeraddr_len);
-		return;
+		return NULL;
 	}
 	tlshd_log_success(parms.peername, parms.peeraddr, parms.peeraddr_len);
+
+	return NULL;
 }

--- a/src/tlshd/netlink.c
+++ b/src/tlshd/netlink.c
@@ -123,11 +123,7 @@ static int tlshd_genl_event_handler(struct nl_msg *msg,
 	    HANDSHAKE_HANDLER_CLASS_TLSHD)
 		return NL_SKIP;
 
-	if (!fork()) {
-		/* child */
-		tlshd_service_socket();
-		exit(EXIT_SUCCESS);
-	}
+	g_thread_new("tlshd_socket", tlshd_service_socket, NULL);
 
 	return NL_SKIP;
 }

--- a/src/tlshd/tlshd.h
+++ b/src/tlshd/tlshd.h
@@ -68,7 +68,7 @@ bool tlshd_config_get_server_privkey(gnutls_privkey_t *privkey);
 /* handshake.c */
 extern void tlshd_start_tls_handshake(gnutls_session_t session,
 				      struct tlshd_handshake_parms *parms);
-extern void tlshd_service_socket(void);
+extern void *tlshd_service_socket(void *session_ptr);
 
 /* keyring.c */
 extern bool tlshd_keyring_get_psk_username(key_serial_t serial,


### PR DESCRIPTION
Currently tlshd uses `fork()` to fork the entire process and then call the tlshd_service_socket() function and exit.

The problem with the current setup is that it makes it very difficult to share information between tlshd_service_socket() and the parent process.

In the future we would like to support the TLS KeyUpdate mechanism, which means we need to maintain the `gnutls_session_t session` information for a connection to allow us to issue a KeyUpdate.

As such this patch changes the current `fork()` multi-process mechanism to a `g_thread_new()` threading mechanism. There are no other changes, just instead of creating new processes we create new threads.

In the future this will allow us to maintain the `gnutls_session_t session` in the parent process, allowing KeyUpdate support.

In theory this should also reduce the overhead of calling `tlshd_service_socket()` as creating a thread should be less overhead then spawning an entire process.

tlshd already depends on glib, so this doesn't require any new dependencies.