### PR TITLE
tlshd: fix a regression for certificate verification

### DIFF
--- a/src/tlshd/handshake.c
+++ b/src/tlshd/handshake.c
@@ -90,6 +90,8 @@ void tlshd_start_tls_handshake(gnutls_session_t session,
 	} while (ret < 0 && !gnutls_error_is_fatal(ret));
 	tlshd_set_nagle(session, saved);
 	if (ret < 0) {
+		/* Any errors here should default to blocking access: */
+		parms->session_status = EACCES;
 		switch (ret) {
 		case GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR:
 			tlshd_log_cert_verification_error(session);
@@ -100,7 +102,6 @@ void tlshd_start_tls_handshake(gnutls_session_t session,
 			break;
 		default:
 			tlshd_log_notice("tlshd_start_tls_handshake unhandled error %d, returning EACCES\n", ret);
-			parms->session_status = EACCES;
 		}
 		return;
 	}


### PR DESCRIPTION
Commit b010190cfed2 left session_status unset for
GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR.  Fix this by always setting EACCESS in the error handling switch statement.

Fixes: b010190cfed2 ("tlshd: Pass ETIMEDOUT from gnutls to kernel")
Closes: #98