### PR TITLE
tlshd: remove redundant gnutls_global_deinit()

### DIFF
--- a/src/tlshd/client.c
+++ b/src/tlshd/client.c
@@ -611,7 +611,7 @@ void tlshd_quic_clienthello_handshake(struct tlshd_handshake_parms *parms)
 	ret = tlshd_quic_conn_create(&conn, parms);
 	if (ret) {
 		parms->session_status = -ret;
-		return gnutls_global_deinit();
+		return;
 	}
 
 	switch (parms->auth_mode) {

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -577,8 +577,8 @@ void tlshd_quic_serverhello_handshake(struct tlshd_handshake_parms *parms)
 
 	ret = tlshd_quic_conn_create(&conn, parms);
 	if (ret) {
-		parms->session_status = ret;
-		return gnutls_global_deinit();
+		parms->session_status = -ret;
+		return;
 	}
 
 	switch (parms->auth_mode) {


### PR DESCRIPTION
The call to gnutls_global_deinit() in tlshd_quic_clienthello_handshake() and tlshd_quic_serverhello_handshake() is redundant, as it is already invoked by their common caller tlshd_service_socket(). Remove these unbalanced deinitialization calls to avoid potential misuse or double deinitialization.

Additionally, fix the error handling to assign -ret to session_status instead of ret for consistency with other error paths.