### PR TITLE
Fix signal handling

### DIFF
--- a/src/tlshd/main.c
+++ b/src/tlshd/main.c
@@ -61,17 +61,6 @@ static void usage(char *progname)
 	fprintf(stderr, "usage: %s [-chsv]\n", progname);
 }
 
-static void tlshd_sigint(int signum)
-{
-	if (signum == SIGINT) {
-		tlshd_gnutls_priority_deinit();
-		tlshd_config_shutdown();
-		tlshd_log_shutdown();
-		tlshd_log_close();
-		exit(EXIT_SUCCESS);
-	}
-}
-
 int main(int argc, char **argv)
 {
 	static gchar config_file[PATH_MAX + 1] = "/etc/tlshd.conf";
@@ -123,8 +112,6 @@ int main(int argc, char **argv)
 		tlshd_log_close();
 		return EXIT_FAILURE;
 	}
-
-	signal(SIGINT, tlshd_sigint);
 
 	tlshd_genl_dispatch();
 

--- a/src/tlshd/netlink.c
+++ b/src/tlshd/netlink.c
@@ -159,6 +159,7 @@ void tlshd_genl_dispatch(void)
 	/* Initialise signal poll mask */
 	sigemptyset(&tlshd_sig_poll_mask);
 	sigaddset(&tlshd_sig_poll_mask, SIGINT);
+	sigaddset(&tlshd_sig_poll_mask, SIGTERM);
 
 	err = tlshd_genl_sock_open(&tlshd_notification_nls);
 	if (err)


### PR DESCRIPTION
The signal handler added for SIGINT in commit bdc1bdb69715d9eb15086102989fa2c58296066e is unsafe, as it calls (indirectly) free() and exit() which are not signal-safe functions.

This reverts that change and switches to a poll()-based event loop that handles signals without using a signal handler.

It also adds handling of SIGTERM, which is the signal that systemd will send to stop the service.