### PR TITLE
tlshd: fix a couple of compiling errors with QUIC enabled

### DIFF
--- a/src/tlshd/client.c
+++ b/src/tlshd/client.c
@@ -486,7 +486,7 @@ static int tlshd_quic_client_set_x509_session(struct tlshd_quic_conn *conn)
 	ret = gnutls_certificate_allocate_credentials(&cred);
 	if (ret)
 		goto err;
-	ret = tlshd_client_get_truststore(xcred);
+	ret = tlshd_client_get_truststore(cred);
 	if (ret != GNUTLS_E_SUCCESS)
 		goto err_cred;
 
@@ -541,7 +541,7 @@ static int tlshd_quic_client_set_anon_session(struct tlshd_quic_conn *conn)
 
 static int tlshd_quic_client_set_psk_session(struct tlshd_quic_conn *conn)
 {
-	key_serial_t peerid = conn->parms->peerids[0];
+	key_serial_t peerid = g_array_index(conn->parms->peerids, key_serial_t, 0);
 	gnutls_psk_client_credentials_t cred;
 	gnutls_session_t session;
 	char *identity = NULL;

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -478,7 +478,6 @@ static int tlshd_quic_server_set_x509_session(struct tlshd_quic_conn *conn)
 	gnutls_datum_t ticket_key;
 	gnutls_session_t session;
 	int ret = -EINVAL;
-	char *cafile;
 
 	if (!tlshd_x509_server_get_certs(parms) || !tlshd_x509_server_get_privkey(parms)) {
 		tlshd_log_error("cert/privkey get error %d", -ret);


### PR DESCRIPTION
This patch fixes these compiling errors with QUIC enabled:

client.c: In function ‘tlshd_quic_client_set_x509_session’: client.c:489:43: error: ‘xcred’ undeclared (first use in this function);
  did you mean ‘cred’?
  489 |         ret = tlshd_client_get_truststore(xcred);
      |                                           ^~~~~
      |                                           cred

client.c:489:43: note: each undeclared identifier is reported only once
  for each function it appears in
client.c: In function ‘tlshd_quic_client_set_psk_session’: client.c:544:31: error: incompatible types when initializing type
  ‘key_serial_t’ {aka ‘int’} using type ‘GArray’ {aka ‘struct _GArray’}
  544 |         key_serial_t peerid = conn->parms->peerids[0];
      |                               ^~~~

server.c: In function ‘tlshd_quic_server_set_x509_session’: server.c:481:15: error: unused variable ‘cafile’ [-Werror=unused-variable]
  481 |         char *cafile;
      |               ^~~~~~

Commit fe3a78aaef92 ("tlshd: Refactor trust store management") passed incorrect 'xcred' to tlshd_client_get_truststore(), while it should be 'cred'. The unused variable 'cafile' should also be cleaned in tlshd_quic_server_set_x509_session().

Commit 18b04a63fc01 ("tlshd: Store peer IDs in a GArray") forgot to fix the parms->peerids access in tlshd_quic_client_set_psk_session().

Fixes: fe3a78aaef92 ("tlshd: Refactor trust store management")
Fixes: 18b04a63fc01 ("tlshd: Store peer IDs in a GArray")