### PR TITLE
tlshd: Return a non-zero peerid

### DIFF
--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -224,6 +224,8 @@ static int tlshd_server_x509_verify_function(gnutls_session_t session,
 			return GNUTLS_E_CERTIFICATE_ERROR;
 		}
 		peerid = tlshd_keyring_create_cert(cert, parms->peername);
+		if (peerid == TLS_NO_PEERID)
+			peerid = UINT_MAX;
 		g_array_append_val(parms->remote_peerids, peerid);
 		gnutls_x509_crt_deinit(cert);
 	}


### PR DESCRIPTION
NFSD depends on seeing a non-zero peerid to know when the session has been authenticated (mTLS). Currently NFSD does not read or parse the remote peer's certificate.

If tlshd fails to link the certificate onto the USER_SPEC keyring, it still needs to return a peerid that is non-zero to show that the remote peer presented a trusted certificate.

Hack city. But this "fix" is compatible with older kernels and ktls-utils releases. A more complete fix is forthcoming.