### PR TITLE
tlshd: fixup compile errors with HAVE_GNUTLS_PSK_ALLOCATE_CREDENTIALS2

### DIFF
--- a/src/tlshd/client.c
+++ b/src/tlshd/client.c
@@ -361,7 +361,8 @@ static void tlshd_tls13_client_psk_handshake_one(struct tlshd_handshake_parms *p
 	gnutls_psk_client_credentials_t psk_cred;
 	gnutls_session_t session;
 #ifdef HAVE_GNUTLS_PSK_ALLOCATE_CREDENTIALS2
-	int version, type, hash;
+	int version, hash;
+	char type;
 #endif
 	gnutls_datum_t key;
 	unsigned int flags;

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -372,7 +372,7 @@ static void tlshd_tls13_server_psk_handshake(struct tlshd_handshake_parms *parms
 
 #ifdef HAVE_GNUTLS_PSK_ALLOCATE_CREDENTIALS2
 	ret = gnutls_psk_allocate_server_credentials2(&psk_cred,
-						      GNUTLS_MAC_NONE);
+						      GNUTLS_MAC_UNKNOWN);
 #else
 	ret = gnutls_psk_allocate_server_credentials(&psk_cred);
 #endif


### PR DESCRIPTION
Fixes the following compile errors when HAVE_GNUTLS_PSK_ALLOCATE_CREDENTIALS2 is enabled.

```
client.c:369:40: error: format ‘%c’ expects argument of type ‘char *’,
but argument 4 has type ‘int *’ [-Werror=format=]
  369 |         if (sscanf(identity, "NVMe%01d%c%02d %*s",
      |                                       ~^
      |                                        |
      |                                        char *
      |                                       %lc
  370 |                    &version, &type, &hash) == 3) {
      |                              ~~~~~
      |                              |
      |                              int *
server.c: In function ‘tlshd_tls13_server_psk_handshake’:
server.c:332:55: error: ‘GNUTLS_MAC_NONE’ undeclared
(first use in this function); did you mean ‘GNUTLS_EXT_NONE’?
  332 |                                                       GNUTLS_MAC_NONE);
      |                                                       ^~~~~~~~~~~~~~~
      |                                                       GNUTLS_EXT_NONE

```
Note that `gnutls_psk_allocate_server_credentials2()` accepts one of
`GNUTLS_MAC_UNKNOWN`, `GNUTLS_MAC_SHA256` or `GNUTLS_MAC_SHA384` as the
`mac` argument. Currently, `GNUTLS_MAC_NONE` does not exist in GnuTLS,
this patch changes this invalid type to `GNUTLS_MAC_UNKNOWN`.

Fixes: https://github.com/oracle/ktls-utils/commit/a5a25e9fb09f3602b376bcce23f99703e03430d8 ("tlshd: use gnutls_psk_allocate_{client,server}_credentials2")