### PR TITLE
Address the ENOPKG returns from add_key(2)

### DIFF
--- a/README
+++ b/README
@@ -15,9 +15,24 @@ this package is released.
 
 ## Dependencies
 
-* The local kernel must have net/handshake support and be built with
-  CONFIG_TLS enabled
-* The local build environment requires GnuTLS and keyutils
+### Run-time dependencies
+
+The kernel must have net/handshake support (v6.5 or later) and be
+built with the following CONFIG options enabled:
+
+* CONFIG_TLS
+* CONFIG_KEYS
+* CONFIG_KEYS_REQUEST_CACHE
+
+### Build dependencies
+
+The build environment requires the development packages for the
+following libraries to be installed:
+
+* GnuTLS
+* keyutils
+* GLib-2.0
+* libnl3
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,24 @@ this package is released.
 
 ## Dependencies
 
-* The local kernel must have net/handshake support and be built with
-  CONFIG_TLS enabled
-* The local build environment requires GnuTLS and keyutils
+### Run-time dependencies
+
+The kernel must have net/handshake support (v6.5 or later) and be
+built with the following CONFIG options enabled:
+
+* CONFIG_TLS
+* CONFIG_KEYS
+* CONFIG_KEYS_REQUEST_CACHE
+
+### Build dependencies
+
+The build environment requires the development packages for the
+following libraries to be installed:
+
+* GnuTLS
+* keyutils
+* GLib-2.0
+* libnl3
 
 ## Installation
 

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -224,8 +224,6 @@ static int tlshd_server_x509_verify_function(gnutls_session_t session,
 			return GNUTLS_E_CERTIFICATE_ERROR;
 		}
 		peerid = tlshd_keyring_create_cert(cert, parms->peername);
-		if (peerid == TLS_NO_PEERID)
-			peerid = UINT_MAX;
 		g_array_append_val(parms->remote_peerids, peerid);
 		gnutls_x509_crt_deinit(cert);
 	}


### PR DESCRIPTION
The kernel was built incorrectly (a CONFIG setting was unintentionally disabled) which resulted in add_key(2) calls failing. This in turn caused NFSD to treat all TLS connections as xprtsec=tls (no mTLS).