### PR TITLE
workflows: Fix permission setting on new MUSL job

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -45,6 +45,7 @@ jobs:
   build-musl:
 
     runs-on: ubuntu-latest
+    permissions: read-all
     container: alpine:latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Specify the permission setting on all jobs in the "Build test" workflow.