### PR TITLE
Relocate man pages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,7 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_LANG(C)
 AC_PROG_CC
 AC_PROG_INSTALL
+AC_PROG_MKDIR_P
 
 unitdir=/usr/lib/systemd/system
 AC_ARG_WITH(systemd,
@@ -93,5 +94,12 @@ fi
 
 AC_SUBST([AM_CPPFLAGS])
 
-AC_CONFIG_FILES([Makefile src/Makefile src/tlshd/Makefile systemd/Makefile])
+AC_CONFIG_FILES([Makefile \
+                 man/Makefile \
+                 man/man5/Makefile \
+                 man/man8/Makefile \
+                 src/Makefile \
+                 src/tlshd/Makefile \
+                 systemd/Makefile])
+
 AC_OUTPUT

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Oracle and/or its affiliates.
+# Copyright (c) 2025 Oracle and/or its affiliates.
 #
 # ktls-utils is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,9 +16,6 @@
 # 02110-1301, USA.
 #
 
-AUTOMAKE_OPTIONS	= foreign
+SUBDIRS			= man5 man8
 
-EXTRA_DIST		= autogen.sh CONTRIBUTING.md LICENSE.txt \
-			  README.md SECURITY.md
-SUBDIRS			= man src systemd
-MAINTAINERCLEANFILES	= Makefile.in cscope.* ktls-utils*.tar.gz
+MAINTAINERCLEANFILES	= Makefile.in

--- a/man/man5/Makefile.am
+++ b/man/man5/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Oracle and/or its affiliates.
+# Copyright (c) 2025 Oracle and/or its affiliates.
 #
 # ktls-utils is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,9 +16,6 @@
 # 02110-1301, USA.
 #
 
-AUTOMAKE_OPTIONS	= foreign
+dist_man5_MANS		= tlshd.conf.5
 
-EXTRA_DIST		= autogen.sh CONTRIBUTING.md LICENSE.txt \
-			  README.md SECURITY.md
-SUBDIRS			= man src systemd
-MAINTAINERCLEANFILES	= Makefile.in cscope.* ktls-utils*.tar.gz
+MAINTAINERCLEANFILES	= Makefile.in

--- a/man/man5/tlshd.conf.5
+++ b/man/man5/tlshd.conf.5
@@ -22,7 +22,7 @@
 .SH NAME
 tlshd.conf \- tlshd configuration file
 .SH SYNOPSIS
-.B /etc/tlshd.conf
+.I /etc/tlshd.conf
 .SH DESCRIPTION
 The
 .B tlshd

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Oracle and/or its affiliates.
+# Copyright (c) 2025 Oracle and/or its affiliates.
 #
 # ktls-utils is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,9 +16,6 @@
 # 02110-1301, USA.
 #
 
-AUTOMAKE_OPTIONS	= foreign
+dist_man8_MANS		= tlshd.8
 
-EXTRA_DIST		= autogen.sh CONTRIBUTING.md LICENSE.txt \
-			  README.md SECURITY.md
-SUBDIRS			= man src systemd
-MAINTAINERCLEANFILES	= Makefile.in cscope.* ktls-utils*.tar.gz
+MAINTAINERCLEANFILES	= Makefile.in

--- a/man/man8/tlshd.8
+++ b/man/man8/tlshd.8
@@ -28,14 +28,13 @@ The
 .B tlshd
 program implements a user agent that services TLS handshake requests
 on behalf of kernel TLS consumers.
-Using the
-.BR accept (2)
-system call, it materializes kernel socket endpoints in user space
-in order to perform TLS handshakes using a TLS library.
+It materializes kernel socket endpoints in user space
+in order to perform TLS handshakes using a standard TLS library.
 After each handshake completes,
 .B tlshd
 plants TLS session metadata into the kernel socket to enable
-the use of kTLS to secure subsequent communication on that socket.
+the use of kTLS to secure subsequent communication on that socket,
+and passes the socket back to the kernel.
 .SH OPTIONS
 .TP
 .B \-c " or " \-\-config

--- a/src/tlshd/Makefile.am
+++ b/src/tlshd/Makefile.am
@@ -18,10 +18,6 @@
 
 dist_sysconf_DATA	= tlshd.conf
 
-man5_MANS		= tlshd.conf.man
-man8_MANS		= tlshd.man
-EXTRA_DIST		= $(man5_MANS) $(man8_MANS)
-
 sbin_PROGRAMS		= tlshd
 tlshd_CFLAGS		= -Werror -Wall -Wextra $(LIBGNUTLS_CFLAGS) \
 			  $(LIBKEYUTILS_CFLAGS) $(GLIB_CFLAGS) $(LIBNL3_CFLAGS) \


### PR DESCRIPTION
Initially I copied the nfs-utils style of situating man pages in the src/ tree along side the tools they document.

However, build systems, package integrators, and development tools appear to expect man pages to reside under:

  ${topdir}/man/man?

And I'm beginning to encounter some naming conflicts under src/tlshd/.

Relocate the man pages from src/ and construct a proper section- based man folder hierarchy.