### PR TITLE
Release ktls-utils 1.3.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 Change Log - In newest-release-first order
 
-ktls-utils 1.3.0 2025-10-06
+ktls-utils 1.3.0 2025-10-20
  * Implement support for certificates using post-quantum encryption
  * Add several new GitHub Action workflows, including a gh-pages generator
  * Move /etc/tlshd.conf to /etc/tlshd/config

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-ktls-utils 1.3.0 2025-10-06
+ktls-utils 1.3.0 2025-10-20
  * Implement support for certificates using post-quantum encryption
  * Add several new GitHub Action workflows, including a gh-pages generator
  * Move /etc/tlshd.conf to /etc/tlshd/config

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 1.3.0-rc1
+# Release Notes for ktls-utils 1.3.0
 
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 1.3.0-rc1
+# Release Notes for ktls-utils 1.3.0
 
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ dnl 02110-1301, USA.
 dnl
 
 AC_PREREQ([2.69])
-AC_INIT([ktls-utils],[1.3.0-rc1],[kernel-tls-handshake@lists.linux.dev])
+AC_INIT([ktls-utils],[1.3.0],[kernel-tls-handshake@lists.linux.dev])
 AM_INIT_AUTOMAKE
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([config.h.in])


### PR DESCRIPTION
ktls-utils 1.3.0 2025-10-20
 * Implement support for certificates using post-quantum encryption
 * Add several new GitHub Action workflows, including a gh-pages generator
 * Move /etc/tlshd.conf to /etc/tlshd/config
 * Smarter signal handling