### PR TITLE
tlshd: use gnutls_handshake_write() for Session Ticket processing in quic

### DIFF
--- a/src/tlshd/quic.c
+++ b/src/tlshd/quic.c
@@ -697,7 +697,10 @@ static void tlshd_quic_recv_session_ticket(struct tlshd_quic_conn *conn)
 		return;
 
 	/* process new session ticket msg and get the generated session data */
-	if (quic_handshake_crypto_data(conn, QUIC_CRYPTO_APP, conn->ticket, len)) {
+	ret = gnutls_handshake_write(session, GNUTLS_ENCRYPTION_LEVEL_APPLICATION,
+				     conn->ticket, len);
+	if (ret && gnutls_error_is_fatal(ret)) {
+		tlshd_log_gnutls_error(ret);
 		conn->errcode = EACCES;
 		return;
 	}


### PR DESCRIPTION
When retrieving session data, GnuTLS must not run a full gnutls_handshake() while processing a TLS Session Ticket message.  The existing code called quic_handshake_process(), which internally invoked gnutls_handshake() and caused failures with the latest GnuTLS versions.

Fix this by calling gnutls_handshake_write() directly in quic_session_get_data() when handling the Session Ticket message.