### PR TITLE
Doxygen: Optimize generated documentation for C

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -297,7 +297,7 @@ ALIASES                =
 # members will be omitted, etc.
 # The default value is: NO.
 
-OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_FOR_C  = YES
 
 # Set the OPTIMIZE_OUTPUT_JAVA tag to YES if your project consists of Java or
 # Python sources only. Doxygen will then generate output that is more tailored


### PR DESCRIPTION
The ktls-utils project uses only C code, no C++. So the documentation can be tuned so it doesn't contain unnecessary C++ isms.