### PR TITLE
tlshd: probe the attributes with correct attribute length

### DIFF
--- a/src/tlshd/netlink.c
+++ b/src/tlshd/netlink.c
@@ -253,7 +253,18 @@ static bool tlshd_probe_attr(struct nl_sock *nls, int cmd, int attr_type)
 		return false;
 	}
 
-	nla_put_string(msg, attr_type, "__probe__");
+	switch (attr_type) {
+	case HANDSHAKE_A_DONE_TAG:
+		nla_put_string(msg, attr_type, "__probe__");
+		break;
+	case HANDSHAKE_A_DONE_REMOTE_AUTH:
+		nla_put_s32(msg, attr_type, 0);
+		break;
+	default:
+		tlshd_log_error("Attribute %d not supported", attr_type);
+		nlmsg_free(msg);
+		return false;
+	}
 
 	err = nl_send_auto(nls, msg);
 	nlmsg_free(msg);


### PR DESCRIPTION
During probing of attributes, kernel can validate attribute length, which triggers warning:

netlink: 'tlshd': attribute type 3 has an invalid length.

Probing should send appropriate attribute length. This is a minimal way to do it, certainly not perfect.

Closes: #140