### PR TITLE
Release ktls-utils 1.4.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 Change Log - In newest-release-first order
 
-ktls-utils 1.4.0 2026-04-08
+ktls-utils 1.4.0 2026-04-27
  * Implement support for TLS record size limits
  * Implement support for QUIC session tickets
  * Implement support for session tags (kernel support still needed)

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-ktls-utils 1.4.0 2026-04-08
+ktls-utils 1.4.0 2026-04-27
  * Implement support for TLS record size limits
  * Implement support for QUIC session tickets
  * Implement support for session tags (kernel support still needed)

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 1.4.0-rc2
+# Release Notes for ktls-utils 1.4.0
 
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Release Notes for ktls-utils 1.4.0-rc2
+# Release Notes for ktls-utils 1.4.0
 
 In-kernel TLS consumers need a mechanism to perform TLS handshakes
 on a connected socket to negotiate TLS session parameters that can

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ dnl 02110-1301, USA.
 dnl
 
 AC_PREREQ([2.69])
-AC_INIT([ktls-utils],[1.4.0-rc2],[kernel-tls-handshake@lists.linux.dev])
+AC_INIT([ktls-utils],[1.4.0],[kernel-tls-handshake@lists.linux.dev])
 AM_INIT_AUTOMAKE
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([config.h.in])


### PR DESCRIPTION
ktls-utils 1.4.0 2026-04-27
 * Implement support for TLS record size limits
 * Implement support for QUIC session tickets
 * Implement support for session tags (kernel support still needed)
 * Add extensible kernel capability detection
 * Add SIGHUP handler for live configuration reload