### PR TITLE
Enable post quantum hybrid ECDHE + ML-KEM groups

### DIFF
--- a/src/tlshd/ktls.c
+++ b/src/tlshd/ktls.c
@@ -479,8 +479,23 @@ static int tlshd_gnutls_priority_init_list(const unsigned int *ciphers,
 		return -ENOMEM;
 
 	/* Prioritize post-quantum EC groups. */
+	pstring = tlshd_string_concat(pstring, ":-GROUP-ALL");
+	if (!pstring)
+		return -ENOMEM;
+
+	if (gnutls_check_version_numeric(3, 8, 8)) {
+		pstring = tlshd_string_concat(pstring, ":+GROUP-X25519-MLKEM768:+GROUP-SECP256R1-MLKEM768");
+		if (!pstring)
+			return -ENOMEM;
+	}
+
+	if (gnutls_check_version_numeric(3, 8, 9)) {
+		pstring = tlshd_string_concat(pstring, ":+GROUP-SECP384R1-MLKEM1024");
+		if (!pstring)
+			return -ENOMEM;
+	}
+
 	pstring = tlshd_string_concat(pstring,
-		":-GROUP-ALL:+GROUP-X25519-MLKEM768:+GROUP-SECP256R1-MLKEM768:+GROUP-SECP384R1-MLKEM1024"
 		":+GROUP-X25519:+GROUP-X448:+GROUP-SECP256R1:+GROUP-SECP384R1:+GROUP-SECP521R1"
 		":+GROUP-FFDHE2048:+GROUP-FFDHE3072:+GROUP-FFDHE4096:+GROUP-FFDHE6144:+GROUP-FFDHE8192"
 	);

--- a/src/tlshd/ktls.c
+++ b/src/tlshd/ktls.c
@@ -478,6 +478,15 @@ static int tlshd_gnutls_priority_init_list(const unsigned int *ciphers,
 	if (!pstring)
 		return -ENOMEM;
 
+	/* Prioritize post-quantum EC groups. */
+	pstring = tlshd_string_concat(pstring,
+		":-GROUP-ALL:+GROUP-X25519-MLKEM768:+GROUP-SECP256R1-MLKEM768:+GROUP-SECP384R1-MLKEM1024"
+		":+GROUP-X25519:+GROUP-X448:+GROUP-SECP256R1:+GROUP-SECP384R1:+GROUP-SECP521R1"
+		":+GROUP-FFDHE2048:+GROUP-FFDHE3072:+GROUP-FFDHE4096:+GROUP-FFDHE6144:+GROUP-FFDHE8192"
+	);
+	if (!pstring)
+		return -ENOMEM;
+
 	/*
 	 * Handshakes must negotiate only ciphers that are supported
 	 * by kTLS. The list below contains the ciphers that are

--- a/src/tlshd/ktls.c
+++ b/src/tlshd/ktls.c
@@ -478,6 +478,28 @@ static int tlshd_gnutls_priority_init_list(const unsigned int *ciphers,
 	if (!pstring)
 		return -ENOMEM;
 
+	/* Enable post-quantum ECDHE + ML-KEM hybrid groups. */
+	if (gnutls_group_get_id("X25519-MLKEM768")) {
+		pstring = tlshd_string_concat(pstring,
+			":+GROUP-X25519-MLKEM768");
+		if (!pstring)
+			return -ENOMEM;
+	}
+
+	if (gnutls_group_get_id("SECP256R1-MLKEM768")) {
+		pstring = tlshd_string_concat(pstring,
+			":+GROUP-SECP256R1-MLKEM768");
+		if (!pstring)
+			return -ENOMEM;
+	}
+
+	if (gnutls_group_get_id("SECP384R1-MLKEM1024")) {
+		pstring = tlshd_string_concat(pstring,
+			":+GROUP-SECP384R1-MLKEM1024");
+		if (!pstring)
+			return -ENOMEM;
+	}
+
 	/*
 	 * Handshakes must negotiate only ciphers that are supported
 	 * by kTLS. The list below contains the ciphers that are


### PR DESCRIPTION
this patch enables post-quantum ECDHE + ML-KEM hybrid groups. (i.e. those which suffixed with `-MLKEM768` or `-MLKEM1024`)

"store-now-decrypt-later" attack conducted by adversaries who have access to quantum computers could be mitigated by enable quantum-safe key exchange algorithms, which strengthened security for RPC-TLS.