### PR TITLE
tlshd/handshake: handle the UNKNOWN_PSK_IDENTITY alert

### DIFF
--- a/src/tlshd/handshake.c
+++ b/src/tlshd/handshake.c
@@ -119,6 +119,10 @@ void tlshd_start_tls_handshake(gnutls_session_t session,
 		case GNUTLS_E_WARNING_ALERT_RECEIVED:
 		case GNUTLS_E_FATAL_ALERT_RECEIVED:
 			tlshd_log_alert(session);
+			if (gnutls_alert_get(session) ==
+			    GNUTLS_A_UNKNOWN_PSK_IDENTITY) {
+				parms->session_status = EKEYREJECTED;
+			}
 			break;
 		default:
 			tlshd_log_gnutls_error(ret);


### PR DESCRIPTION
During TLS handshake, an endpoint may issue an UNKNOWN_PSK_IDENTITY alert if it does not recognize the PSK identifier. For example, when using NVMe TCP in-band authentication with secure concatenation, if the target resets; the host kernel attempts to reconnect using a stale PSK, which the re-initialized target no longer recognizes.

Map this specific TLS alert to EKEYREJECTED. This allows the kernel to identify that the failure is due to stale credentials, trigger key revocation, and proceed with fresh in-band authentication on the next reconnection attempt.