### PR TITLE
tlshd: Add support for loading GnuTLS URL-based private keys

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,9 @@ AC_CHECK_LIB([gnutls], [gnutls_psk_allocate_client_credentials2],
 AC_CHECK_LIB([gnutls], [gnutls_record_get_max_send_size],
              [AC_DEFINE([HAVE_GNUTLS_RECORD_GET_MAX_SEND_SIZE], [1],
 			[Define to 1 if you have the gnutls_record_get_max_send_size function.])])
+AC_CHECK_LIB([gnutls], [gnutls_privkey_import_url],
+             [AC_DEFINE([HAVE_GNUTLS_PRIVKEY_IMPORT_URL], [1],
+                        [Define to 1 if you have gnutls_privkey_import_url.])])
 AC_CHECK_LIB([glib-2.0], [g_pattern_spec_match],
              [AC_DEFINE([HAVE_GLIB_G_PATTERN_SPEC_MATCH], [1],
                         [Define to 1 if you have the g_pattern_spec_match function.])])

--- a/man/man5/tlshd.conf.5
+++ b/man/man5/tlshd.conf.5
@@ -126,8 +126,10 @@ a PEM-encoded x.509 certificate that is to be presented during
 a handshake request when no other certificate is available.
 .TP
 .B x509.private_key
-This option specifies the pathname of a file containing
-a PEM-encoded private key associated with the above certificate.
+This option specifies the private key associated with the above
+certificate, either in the pathname of a key file in PEM encoding,
+or a GnuTLS-compatible key URL. In case of ambiguity where a relative
+path may be interpreted as a URL, prefix the path with "./".
 .TP
 .B x509.pq.certificate
 This option specifies the pathname of a file containing
@@ -141,8 +143,10 @@ certificate configured in the
 option will be presented instead.
 .TP
 .B x509.pq.private_key
-This option specifies the pathname of a file containing
-a PEM-encoded private key associated with the above certificate.
+This option specifies the private key associated with the above
+certificate, either in the pathname of a key file in PEM encoding,
+or a GnuTLS-compatible key URL. In case of ambiguity where a relative
+path may be interpreted as a URL, prefix the path with "./".
 .SH SEE ALSO
 .BR tlshd (8),
 .BR tls-session-tags (7)

--- a/src/tlshd/config.c
+++ b/src/tlshd/config.c
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 
+#include <ctype.h>
 #include <stdbool.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -538,6 +539,76 @@ bool tlshd_config_get_certs(int peer_type, gnutls_pcert_st *certs,
 }
 
 /**
+ * @brief Determine if a string looks like a URL by checking for a RFC 3986 scheme prefix
+ * @param[in]      str URL or file path
+ * @retval true  str looks like a URL (has a scheme prefix)
+ * @retval false str does not have a URL scheme prefix
+ */
+static bool __tlshd_is_url(const char *str)
+{
+	if (!isalpha(*str))
+		return false;
+	for (str++; *str; str++) {
+		if (*str == ':')
+			return true;
+		if (!isalnum(*str) && *str != '+' && *str != '-' && *str != '.')
+			return false;
+	}
+	return false;
+}
+
+#ifdef HAVE_GNUTLS_PRIVKEY_IMPORT_URL
+/**
+ * @brief Copy the scheme portion of a URL, colon included.
+ * @param[in]      str URL string
+ * @returns a newly allocated string containing the URL scheme, or an empty string
+ * if no colon is found. Caller must free the returned string using free().
+ */
+static char *__tlshd_copy_url_scheme(const char *url)
+{
+	const char *colon = strchr(url, ':');
+	if (!colon)
+		return strdup("");
+	return strndup(url, colon + 1 - url);
+}
+
+/**
+ * @brief Helper to retrieve URL-based private keys
+ * @param[in]      url        URL to load private key from
+ * @param[out]     privkey    in-memory private key
+ *
+ * @retval true   Private key retrieved successfully
+ * @retval false  Private key not retrieved
+ */
+static bool __tlshd_config_get_url_privkey(const char *url, gnutls_privkey_t *privkey)
+{
+	gnutls_privkey_t privkey_out;
+	int ret;
+
+	ret = gnutls_privkey_init(&privkey_out);
+	if (ret != GNUTLS_E_SUCCESS) {
+		tlshd_log_gnutls_error(ret);
+		return false;
+	}
+
+	ret = gnutls_privkey_import_url(privkey_out, url, 0);
+	if (ret != GNUTLS_E_SUCCESS) {
+		tlshd_log_gnutls_error(ret);
+		gnutls_privkey_deinit(privkey_out);
+		return false;
+	}
+
+	if (tlshd_debug > 0) {
+		char *url_scheme = __tlshd_copy_url_scheme(url);
+		tlshd_log_debug("Retrieved private key from %s<redacted>", url_scheme);
+		free(url_scheme);
+	}
+	*privkey = privkey_out;
+	return true;
+}
+#endif
+
+/**
  * @brief Helper for tlshd_config_get_privkey()
  * @param[in]      peer_type  peer type
  * @param[out]     privkey    in-memory private key
@@ -562,6 +633,28 @@ static bool __tlshd_config_get_privkey(int peer_type, gnutls_privkey_t *privkey,
 					 NULL);
 	if (!pathname)
 		return false;
+
+	if (__tlshd_is_url(pathname)) {
+#ifdef HAVE_GNUTLS_PRIVKEY_IMPORT_URL
+		if (!gnutls_url_is_supported(pathname)) {
+			if (tlshd_debug > 0) {
+				char *url_scheme = __tlshd_copy_url_scheme(pathname);
+				tlshd_log_debug("Failed to retrieve private key. "
+				                "GnuTLS does not support %s<redacted> URL.", url_scheme);
+				free(url_scheme);
+			}
+			g_free(pathname);
+			return false;
+		}
+		ret = __tlshd_config_get_url_privkey(pathname, privkey);
+#else
+		tlshd_log_debug("Failed to retrieve private key. "
+		                "GnuTLS does not support URL-based private keys.");
+		ret = false;
+#endif
+		g_free(pathname);
+		return ret;
+	}
 
 	if (!tlshd_config_read_datum(pathname, &data, TLSHD_OWNER,
 				     TLSHD_PRIVKEY_MODE)) {


### PR DESCRIPTION
GnuTLS can be built to support abstract keys that don't expose internal parameters. e.g. keys backed by HSM, PKCS11 tokens, other system-specific keyrings. This patch adds code path in config parsing to invoke abstract key API when key URLs are detected. For example:

x509.private_key=pkcs11:token=MySmartToken;object=MyVerySecretKey