### PR TITLE
tlshd: Deinit output variable in __tlshd_config_get_privkey on error

### DIFF
--- a/src/tlshd/config.c
+++ b/src/tlshd/config.c
@@ -548,6 +548,7 @@ bool tlshd_config_get_certs(int peer_type, gnutls_pcert_st *certs,
  */
 static bool __tlshd_config_get_privkey(int peer_type, gnutls_privkey_t *privkey, bool pq)
 {
+	gnutls_privkey_t privkey_out = NULL;
 	gnutls_datum_t data;
 	gchar *pathname;
 	int ret;
@@ -569,7 +570,7 @@ static bool __tlshd_config_get_privkey(int peer_type, gnutls_privkey_t *privkey,
 		return false;
 	}
 
-	ret = gnutls_privkey_init(privkey);
+	ret = gnutls_privkey_init(&privkey_out);
 	if (ret != GNUTLS_E_SUCCESS) {
 		tlshd_log_gnutls_error(ret);
 		free(data.data);
@@ -578,17 +579,19 @@ static bool __tlshd_config_get_privkey(int peer_type, gnutls_privkey_t *privkey,
 	}
 
 	/* Config file supports only PEM-encoded keys */
-	ret = gnutls_privkey_import_x509_raw(*privkey, &data,
+	ret = gnutls_privkey_import_x509_raw(privkey_out, &data,
 					     GNUTLS_X509_FMT_PEM, NULL, 0);
 	free(data.data);
 	if (ret != GNUTLS_E_SUCCESS) {
 		tlshd_log_gnutls_error(ret);
+		gnutls_privkey_deinit(privkey_out);
 		g_free(pathname);
 		return false;
 	}
 
 	tlshd_log_debug("Retrieved private key from %s", pathname);
 	g_free(pathname);
+	*privkey = privkey_out;
 	return true;
 }
 

--- a/src/tlshd/server.c
+++ b/src/tlshd/server.c
@@ -113,6 +113,7 @@ static void tlshd_x509_server_put_certs(void)
 
 	for (i = 0; i < TLSHD_MAX_CERTS; i++)
 		gnutls_pcert_deinit(&tlshd_server_certs[i]);
+	memset(tlshd_server_certs, 0, sizeof(tlshd_server_certs));
 }
 
 /**
@@ -139,7 +140,9 @@ static bool tlshd_x509_server_get_privkey(struct tlshd_handshake_parms *parms)
 static void tlshd_x509_server_put_privkey(void)
 {
 	gnutls_privkey_deinit(tlshd_server_pq_privkey);
+	tlshd_server_pq_privkey = NULL;
 	gnutls_privkey_deinit(tlshd_server_privkey);
+	tlshd_server_privkey = NULL;
 }
 
 /**
@@ -728,7 +731,7 @@ static void tlshd_quic_server_set_x509_session(struct tlshd_quic_conn *conn)
 
 	if (!tlshd_x509_server_get_certs(parms) || !tlshd_x509_server_get_privkey(parms)) {
 		tlshd_log_error("Failed to get cert or privkey");
-		return;
+		goto err_config;
 	}
 
 	ret = gnutls_certificate_allocate_credentials(&cred);
@@ -782,9 +785,10 @@ err_session:
 err_cred:
 	gnutls_certificate_free_credentials(cred);
 err:
+	tlshd_log_gnutls_error(ret);
+err_config:
 	tlshd_x509_server_put_privkey();
 	tlshd_x509_server_put_certs();
-	tlshd_log_gnutls_error(ret);
 }
 
 /**


### PR DESCRIPTION
Fixes a small memory leak where the output variable was constructed but not destructed on error exit.

Fixes: oracle/ktls-utils#156